### PR TITLE
Added octoprint to sudo group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ LABEL issues="github.com/OcotPrint/docker/issues"
 RUN apt-get update && apt-get install -y build-essential
 
 RUN groupadd --gid 1000 octoprint \
-  && useradd --uid 1000 --gid octoprint -G dialout --shell /bin/bash --create-home octoprint
+  && useradd --uid 1000 --gid octoprint -G sudo --shell /bin/bash --create-home octoprint
 
 #Install Octoprint, ffmpeg, and cura engine
 COPY --from=compiler /opt/venv /opt/venv


### PR DESCRIPTION
Dialout group is not effective on base image you are using, either due to missing udev rules, or udev missing entirely.