### PR TITLE
Add camera image variant

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,5 +77,5 @@ jobs:
             --platform linux/arm64,linux/amd64,linux/arm/v7 \
             --cache-from octoprint/octoprint:cache \
             --cache-to octoprint/octoprint:cache \
-            --build-arg OCTOPRINT_BASE_IMAGE=1.4.2 \
+            --build-arg OCTOPRINT_BASE_IMAGE=${{ steps.get-octoprint-release.outputs.release }} \
             --progress plain -t octoprint/octoprint:ci-camera -f ./camera/Dockerfile.camera .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
   # variant builds (such as _camera) will go here
   camera:
     runs-on: ubuntu-latest
+    needs: _default
     
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,6 @@ on:
 jobs:
   _default:
     runs-on: ubuntu-latest
-    env:
-      tag_name: ci
     
     steps:
       - name: Checkout
@@ -46,12 +44,10 @@ jobs:
             --cache-to octoprint/octoprint:cache \
             --build-arg PYTHON_BASE_IMAGE=3.8-slim-buster \
             --build-arg tag=${{ steps.get-octoprint-release.outputs.release }} \
-            --progress plain -t octoprint/octoprint:${{ env.tag_name }} .
+            --progress plain -t octoprint/octoprint:ci .
   # variant builds (such as _camera) will go here
   camera:
     runs-on: ubuntu-latest
-    env:
-      tag_name: ci-camera
     
     steps:
       - name: Checkout
@@ -82,5 +78,5 @@ jobs:
             --cache-from octoprint/octoprint:cache \
             --cache-to octoprint/octoprint:cache \
             --build-arg OCTOPRINT_BASE_IMAGE=${{ steps.get-octoprint-release.outputs.release }} \ 
-            --progress plain -t octoprint/octoprint:${{ env.tag_name }} -f ./camera/Dockerfile.camera .
+            --progress plain -t octoprint/octoprint:ci-camera -f ./camera/Dockerfile.camera .
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build Images
 
 on:
   push:
+    paths-ignore:
+      - 'scripts'
     branches-ignore:
       - master
   pull_request:
@@ -79,7 +81,6 @@ jobs:
             --platform linux/arm64,linux/amd64,linux/arm/v7 \
             --cache-from octoprint/octoprint:cache \
             --cache-to octoprint/octoprint:cache \
-            --build-arg PYTHON_BASE_IMAGE=3.8-slim-buster \
-            --build-arg tag=${{ steps.get-octoprint-release.outputs.release }} \
+            --build-arg OCTOPRINT_BASE_IMAGE=${{ steps.get-octoprint-release.outputs.release }} \ 
             --progress plain -t octoprint/octoprint:${{ env.tag_name }} .
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,5 @@ jobs:
             --platform linux/arm64,linux/amd64,linux/arm/v7 \
             --cache-from octoprint/octoprint:cache \
             --cache-to octoprint/octoprint:cache \
-            --build-arg OCTOPRINT_BASE_IMAGE=${{ steps.get-octoprint-release.outputs.release }} \ 
+            --build-arg OCTOPRINT_BASE_IMAGE=1.4.2 \
             --progress plain -t octoprint/octoprint:ci-camera -f ./camera/Dockerfile.camera .
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,3 +46,40 @@ jobs:
             --build-arg tag=${{ steps.get-octoprint-release.outputs.release }} \
             --progress plain -t octoprint/octoprint:${{ env.tag_name }} .
   # variant builds (such as _camera) will go here
+  camera:
+    runs-on: ubuntu-latest
+    env:
+      tag_name: ci-camera
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get OctoPrint Stable
+        id: get-octoprint-release
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          owner: OctoPrint
+          repo: OctoPrint
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+        with:
+          buildx-version: latest
+          qemu-version: latest
+      - name: Docker login
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+      - name: Build Image
+        id: build
+        run: |
+          docker buildx build --push \
+            --platform linux/arm64,linux/amd64,linux/arm/v7 \
+            --cache-from octoprint/octoprint:cache \
+            --cache-to octoprint/octoprint:cache \
+            --build-arg PYTHON_BASE_IMAGE=3.8-slim-buster \
+            --build-arg tag=${{ steps.get-octoprint-release.outputs.release }} \
+            --progress plain -t octoprint/octoprint:${{ env.tag_name }} .
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,5 +82,5 @@ jobs:
             --cache-from octoprint/octoprint:cache \
             --cache-to octoprint/octoprint:cache \
             --build-arg OCTOPRINT_BASE_IMAGE=${{ steps.get-octoprint-release.outputs.release }} \ 
-            --progress plain -t octoprint/octoprint:${{ env.tag_name }} .
+            --progress plain -t octoprint/octoprint:${{ env.tag_name }} -f ./camera/Dockerfile.camera .
 

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -63,6 +63,7 @@ jobs:
 
   camera:
     runs-on: ubuntu-latest
+    needs: _default
     strategy:
       matrix:
         tags: ['%X%-camera', '%X.Y%-camera', '%X.Y.Z%-camera']

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  release:
+  _default:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -60,4 +60,55 @@ jobs:
             --build-arg PYTHON_BASE_IMAGE=3.8-slim-buster \
             --build-arg tag=${{ env.tag_name }} \
             --progress plain -t octoprint/octoprint:${{ steps.tagging.outputs.tag }} .
+
+  camera:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tags: ['%X%-camera', '%X.Y%-camera', '%X.Y.Z%-camera']
+
+    steps:
+      - name: Get Tag if push
+        id: get-octoprint-release
+        if: ${{ github.event_name == 'push'}}
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          owner: OctoPrint
+          repo: OctoPrint
+      - name: Set Tag on Push
+        if: ${{ github.event_name == 'push'}}
+        run: echo "::set-env name=tag_name::${{ steps.get-octoprint-release.outputs.release }}"
+      - name: Set Tag on dispatch
+        if: ${{ github.event_name == 'repository_dispatch' }}
+        run: echo "::set-env name=tag_name::${{ github.event.client_payload.tag_name }}"
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Tagging strategy
+        id: tagging
+        uses: HackerHappyHour/tagging-strategy@1.0.0
+        with:
+          tag_name: "${{ env.tag_name }}"
+          pattern: "${{ matrix.tags}}"
+
+      - name: Set up Docker Buildx
+        id: setup
+        uses: crazy-max/ghaction-docker-buildx@v3
+        with:
+          buildx-version: latest
+          qemu-version: latest
+      
+      - name: Docker Login
+        id: login
+        run: |
+          echo ${{ secrets.DOCKER_PASSWORD}} | docker login -u ${{ secrets.DOCKER_USERNAME}} --password-stdin
+
+      - name: Build and Deploy
+        id: build_deploy
+        run: |
+          docker buildx build --push \
+            --platform linux/arm64,linux/amd64,linux/arm/v7 \
+            --cache-from octoprint/octoprint:cache \
+            --cache-to octoprint/octoprint:cache \
+            --build-arg OCTOPRINT_BASE_IMAGE=${{ steps.get-octoprint-release.outputs.release }} \
+            --progress plain -t octoprint/octoprint:${{ env.tag_name }} -f ./camera/Dockerfile.camera .
 

--- a/Dockerfile.camera
+++ b/Dockerfile.camera
@@ -1,0 +1,32 @@
+ARG CAMERA_BASE_IMAGE=3.8-slim-buster
+
+FROM ubuntu AS s6build
+ARG S6_RELEASE
+ENV S6_VERSION ${S6_RELEASE:-v2.0.0.1}
+RUN apt-get update && apt-get install -y curl
+RUN echo "$(dpkg --print-architecture)"
+WORKDIR /tmp
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+  amd64) ARCH='amd64';; \
+  arm64) ARCH='arm64';; \
+  armhf) ARCH='armhf';; \
+  *) echo "unsupported architecture: $(dpkg --print-architecture)"; exit 1 ;; \
+  esac \
+  && set -ex \
+  && echo $S6_VERSION \
+  && curl -fsSLO "https://github.com/just-containers/s6-overlay/releases/download/$S6_VERSION/s6-overlay-$ARCH.tar.gz"
+
+
+FROM python:${CAMERA_BASE_IMAGE} AS build
+
+# unpack s6
+COPY --from=s6build /tmp /tmp
+
+RUN apt-get update && apt-get install -y xz-utils
+RUN s6tar=$(find /tmp -name "s6-overlay-*.tar.gz") \
+  && tar xzf $s6tar -C / --exclude './bin' \
+  && tar xzf $s6tar -C /usr ./bin
+
+ENTRYPOINT ["/init"]
+CMD ["nginx"]

--- a/Dockerfile.camera
+++ b/Dockerfile.camera
@@ -1,4 +1,4 @@
-ARG CAMERA_BASE_IMAGE=3.8-slim-buster
+ARG OCTOPRINT_BASE_IMAGE
 
 FROM ubuntu AS s6build
 ARG S6_RELEASE
@@ -18,12 +18,19 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && curl -fsSLO "https://github.com/just-containers/s6-overlay/releases/download/$S6_VERSION/s6-overlay-$ARCH.tar.gz"
 
 
-FROM python:${CAMERA_BASE_IMAGE} AS build
+FROM octoprint/octoprint:${OCTOPRINT_BASE_IMAGE}} AS build
 
 # unpack s6
 COPY --from=s6build /tmp /tmp
 
-RUN apt-get update && apt-get install -y xz-utils
+RUN apt-get update && apt-get install -y \
+  xz-utils \
+  build-essential \
+  g++ \
+  make \
+  curl \
+  haproxy
+
 RUN s6tar=$(find /tmp -name "s6-overlay-*.tar.gz") \
   && tar xzf $s6tar -C / --exclude './bin' \
   && tar xzf $s6tar -C /usr ./bin

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OCTOPRINT_VERSION?= $(shell ./scripts/version.sh "OctoPrint/OctoPrint")
 IMG_TAG=${OCTOPRINT_VERSION}-python3
 
 .DEFAULT_GOAL := build
-.PHONY: camera
+.PHONY: camera buildx-camera
 
 clean:
 	docker stop buildkit && docker rm buildkit
@@ -48,6 +48,14 @@ buildx-push:
 		--progress plain -t ${IMG}:${IMG_TAG} .
 
 camera: 
-	@echo '[buildx]: building camera image'
+	@echo 'building camera image for this hosts platform'
 	docker build --build-arg OCTOPRINT_BASE_IMAGE=1.4.2 \
 		-t octoprint/octoprint:camera -f ./camera/Dockerfile.camera .
+
+buildx-camera: 
+	@echo '[buildx]: building camera image for all supported platforms'
+	docker buildx build --push --platform $(PLATFORMS) \
+	--cache-from ${CACHE} \
+	--cache-to ${CACHE} \
+	--build-arg OCTOPRINT_BASE_IMAGE=1.4.2 \
+	--progress plain -t octoprint/octoprint:ci-camera -f ./camera/Dockerfile.camera .

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ OCTOPRINT_VERSION?= $(shell ./scripts/version.sh "OctoPrint/OctoPrint")
 IMG_TAG=${OCTOPRINT_VERSION}-python3
 
 .DEFAULT_GOAL := build
+.PHONY: camera
 
 clean:
 	docker stop buildkit && docker rm buildkit
@@ -45,3 +46,8 @@ buildx-push:
 		--build-arg PYTHON_BASE_IMAGE=$(PYTHON_BASE_IMAGE) \
 		--build-arg tag=${OCTOPRINT_VERSION} \
 		--progress plain -t ${IMG}:${IMG_TAG} .
+
+camera: 
+	@echo '[buildx]: building camera image'
+	docker build --build-arg OCTOPRINT_BASE_IMAGE=1.4.2 \
+		-t octoprint/octoprint:camera -f ./camera/Dockerfile.camera .

--- a/camera/Dockerfile.camera
+++ b/camera/Dockerfile.camera
@@ -56,9 +56,13 @@ WORKDIR /mjpg/mjpg-streamer-master/mjpg-streamer-experimental
 RUN make
 RUN make install
 
-# Copy services into s6 servicedir
+# Copy services into s6 servicedir and set default ENV vars
 COPY camera /
+ENV CAMERA_DEV /dev/video0
+ENV MJPEG_STREAMER_AUTOSTART true
+ENV MJPEG_STREAMER_INPUT -y -n -r 640x480
 
+# port to access haproxy frontend
 EXPOSE 8888
 
 ENTRYPOINT ["/init"]

--- a/camera/Dockerfile.camera
+++ b/camera/Dockerfile.camera
@@ -18,22 +18,43 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && curl -fsSLO "https://github.com/just-containers/s6-overlay/releases/download/$S6_VERSION/s6-overlay-$ARCH.tar.gz"
 
 
-FROM octoprint/octoprint:${OCTOPRINT_BASE_IMAGE}} AS build
+FROM octoprint/octoprint:${OCTOPRINT_BASE_IMAGE} AS build
+
+USER root
+
+RUN apt-get update && apt-get install -y \
+  avrdude \
+  build-essential \
+  cmake \
+  curl \
+  imagemagick \
+  fontconfig \
+  g++ \
+  git \
+  haproxy \
+  libjpeg-dev \
+  libjpeg62-turbo \
+  libprotobuf-dev \
+  libv4l-dev \
+  openssh-client \
+  v4l-utils \
+  xz-utils \
+  zlib1g-dev
 
 # unpack s6
 COPY --from=s6build /tmp /tmp
-
-RUN apt-get update && apt-get install -y \
-  xz-utils \
-  build-essential \
-  g++ \
-  make \
-  curl \
-  haproxy
-
 RUN s6tar=$(find /tmp -name "s6-overlay-*.tar.gz") \
   && tar xzf $s6tar -C / --exclude './bin' \
   && tar xzf $s6tar -C /usr ./bin
 
+# Install mjpg-streamer
+RUN curl -fsSLO --compressed --retry 3 --retry-delay 10 \
+  https://github.com/jacksonliam/mjpg-streamer/archive/master.tar.gz \
+  && mkdir /mjpg-streamer-master \
+  && tar xzf master.tar.gz -C /
+
+WORKDIR /mjpg-streamer-master/mjpg-streamer-experimental
+RUN make
+RUN make install
+
 ENTRYPOINT ["/init"]
-CMD ["nginx"]

--- a/camera/Dockerfile.camera
+++ b/camera/Dockerfile.camera
@@ -9,7 +9,7 @@ WORKDIR /tmp
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
   amd64) ARCH='amd64';; \
-  arm64) ARCH='arm64';; \
+  arm64) ARCH='aarch64';; \
   armhf) ARCH='armhf';; \
   *) echo "unsupported architecture: $(dpkg --print-architecture)"; exit 1 ;; \
   esac \

--- a/camera/Dockerfile.camera
+++ b/camera/Dockerfile.camera
@@ -58,3 +58,4 @@ RUN make
 RUN make install
 
 ENTRYPOINT ["/init"]
+CMD ["octoprint", "serve", "--iknowwhatimdoing", "--host", "0.0.0.0"]

--- a/camera/Dockerfile.camera
+++ b/camera/Dockerfile.camera
@@ -56,5 +56,10 @@ WORKDIR /mjpg/mjpg-streamer-master/mjpg-streamer-experimental
 RUN make
 RUN make install
 
+# Copy services into s6 servicedir
+COPY camera /
+
+EXPOSE 8888
+
 ENTRYPOINT ["/init"]
 CMD ["octoprint", "serve", "--iknowwhatimdoing", "--host", "0.0.0.0"]

--- a/camera/Dockerfile.camera
+++ b/camera/Dockerfile.camera
@@ -44,16 +44,15 @@ RUN apt-get update && apt-get install -y \
 # unpack s6
 COPY --from=s6build /tmp /tmp
 RUN s6tar=$(find /tmp -name "s6-overlay-*.tar.gz") \
-  && tar xzf $s6tar -C / --exclude './bin' \
-  && tar xzf $s6tar -C /usr ./bin
+  && tar xzf $s6tar -C / 
 
 # Install mjpg-streamer
 RUN curl -fsSLO --compressed --retry 3 --retry-delay 10 \
   https://github.com/jacksonliam/mjpg-streamer/archive/master.tar.gz \
-  && mkdir /mjpg-streamer-master \
-  && tar xzf master.tar.gz -C /
+  && mkdir /mjpg \
+  && tar xzf master.tar.gz -C /mjpg
 
-WORKDIR /mjpg-streamer-master/mjpg-streamer-experimental
+WORKDIR /mjpg/mjpg-streamer-master/mjpg-streamer-experimental
 RUN make
 RUN make install
 

--- a/camera/etc/haproxy/haproxy.cfg
+++ b/camera/etc/haproxy/haproxy.cfg
@@ -1,0 +1,34 @@
+global
+        maxconn 4096
+        user haproxy
+        group haproxy
+        daemon
+        log 127.0.0.1 local0 debug
+
+defaults
+        log     global
+        mode    http
+        option  httplog
+        option  dontlognull
+        retries 3
+        option redispatch
+        option http-server-close
+        option forwardfor
+        maxconn 2000
+        timeout connect 5s
+        timeout client  15min
+        timeout server  15min
+
+frontend public
+        bind *:8888
+        use_backend webcam if { path_beg /webcam/ }
+        default_backend octoprint
+
+backend octoprint
+        reqrep ^([^\ :]*)\ /(.*)     \1\ /\2
+        option forwardfor
+        server octoprint1 127.0.0.1:5000
+
+backend webcam
+        reqrep ^([^\ :]*)\ /webcam/(.*)     \1\ /\2
+        server webcam1  127.0.0.1:8080

--- a/camera/etc/services.d/haproxy/run
+++ b/camera/etc/services.d/haproxy/run
@@ -1,0 +1,3 @@
+#!/usr/bin/execlineb -P
+
+haproxy -p /tmp/haproxy.pid -f /etc/haproxy/haproxy.cfg -db

--- a/camera/etc/services.d/mjpg-streamer/run
+++ b/camera/etc/services.d/mjpg-streamer/run
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+exec /mjpg/mjpg-streamer-master/mjpg-streamer-experimental/mjpg_streamer \
+  -i "/usr/local/lib/mjpg-streamer/input_uvc.so -y -n -r 640x480 -d /dev/video0" \
+  -o "/usr/local/lib/mjpg-streamer/output_http.so -w /usr/local/share/mjpg-streamer/www -p 8080"


### PR DESCRIPTION
- uses s6 process supervisor
- uses the default octoprint image of the same version as the base image
- currently forces `/dev/video0` for webcam input 
  - will require the use of mapping your video drive to `/dev/video0` until we get the `CAMERA_DEV` var supported. Ex...( `-v /dev/video1:/dev/video0`)
- uses non-privileged port of `8888` as the haproxy frontend
- supports `arm64,amd64,armhf` architectures (same as the base image)
- only available in `slim-buster` for now (same as the base image)
- builds 3 tags automatically on releases of OctoPrint, by running the Manual Dispatch action on this repo, or on pushes to master
  - `X-camera`, `X.Y-camera`, `X.Y.Z-camera`
  - X.Y.Z will be equal to the most recent OctoPrint Release or prerelease

closes #47 