### PR TITLE
Switch docker-compose to v2.4 to avoid swarm questions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '2.4'
 
 services:
   octoprint:


### PR DESCRIPTION
docker-compose v3.x is designed to accommodate docker swarm mode. As most people will be using this on a single node lets use v2.4 instead so that we can still constrain resources and avoid a torrent of support issues when people lookup the file format.