### PR TITLE
Revert persistent volume path change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     #  - /dev/ttyACM0:/dev/ttyACM0
     # - /dev/video0:/dev/video0
     volumes:
-     - octoprint:/octoprint
+     - octoprint:/home/octoprint
   
   ####
   # uncomment if you wish to edit the configuration files of octoprint
@@ -29,7 +29,7 @@ services:
   #    - GUID=0
   #    - TZ=America/Chicago
   #  volumes:
-  #    - octoprint:/octoprint
+  #    - octoprint:/home/octoprint
 
 volumes:
   octoprint:


### PR DESCRIPTION
Commit b357bdf249ce0ee20af3a4cc04c7fd791cc8946a changed the persistent volume location from `/home/octoprint` to `/octoprint/`, but octoprint still uses `/home/octoprint` as its config location. Resolves issue #71 . 