### PR TITLE
Fix build filtering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,12 @@ jobs:
       id: filter
       with:
         filters: '.github/filters.yml'
+    - name: debug filters
+      env:
+        FILTER_OUTPUTS: ${{ toJson(steps.filter.outputs)}}
+      run: echo "$FILTER_OUTPUTS" 
 
-  build:
+  docker_build:
     runs-on: ubuntu-latest
     needs: filters
     if: ${{ needs.filters.outputs.found_main_changes }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,6 @@ jobs:
       id: filter
       with:
         filters: '.github/filters.yml'
-    - name: debug filters
-      env:
-        FILTER_OUTPUTS: ${{ toJson(steps.filter.outputs)}}
-      run: echo "$FILTER_OUTPUTS" 
 
   docker_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
   docker_build:
     runs-on: ubuntu-latest
     needs: filters
-    if: ${{ needs.filters.outputs.found_main_changes }}
+    if: ${{ needs.filters.outputs.found_main_changes == 'true' }}
     
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The filtering on the build workflow was always evaluating to `true` because it wasn't doing an actual evaluation of the filter key values.