### PR TITLE
Feature optional mjpeg streamer startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ config/logs
 config/timelapse
 config/uploads
 buildtest
+compose.test.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN make install
 # Copy services into s6 servicedir and set default ENV vars
 COPY root /
 ENV CAMERA_DEV /dev/video0
-ENV MJPEG_STREAMER_INPUT -y -n -r 640x480
+ENV MJPG_STREAMER_INPUT -y -n -r 640x480
 ENV PIP_USER true
 ENV PYTHONUSERBASE /octoprint/plugins
 

--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,17 @@ buildx-camera:
 	--cache-to ${CACHE} \
 	--build-arg OCTOPRINT_BASE_IMAGE=1.4.2 \
 	--progress plain -t octoprint/octoprint:ci-camera -f ./camera/Dockerfile.camera .
+
+test-up:
+	docker-compose -f compose.test.yml up -d
+	@docker-compose -f compose.test.yml logs -f octoprint
+
+test-stop:
+	@docker-compose -f compose.test.yml stop
+
+test-start:
+	docker-compose -f compose.test.yml start
+	@docker-compose -f compose.test.yml logs -f octoprint
+
+test-clean:
+	docker-compose -f compose.test.yml down

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ same out of the box features as the octopi raspberry-pi machine image, using doc
 
 - `latest`, `1.4.2`, `1.4`, `1` ([Dockerfile](Dockerfile))
 
+- [OctoPrint-docker](#octoprint-docker)
+  - [Tags](#tags)
+  - [Usage](#usage)
+    - [Configuration](#configuration)
+      - [Enabling Webcam Support with Docker](#enabling-webcam-support-with-docker)
+      - [Webcam Setup in OctoPrint](#webcam-setup-in-octoprint)
+      - [Container Environment based configs](#container-environment-based-configs)
+      - [Editing Config files manually](#editing-config-files-manually)
+  - [Without docker-compose](#without-docker-compose)
+
 ## Usage
 
 We recommend you use docker-compose to run octoprint via docker, and have included
@@ -22,7 +32,22 @@ launch of OctoPrint using docker.
 
 ### Configuration
 
-#### Initial Setup
+#### Enabling Webcam Support with Docker
+
+In order to use the webcam, you'll need to make sure the webcam service is enabled. 
+This is done by setting the environment variable `MJPEG_STREAMER_AUTOSTART=true` in your
+`docker run` command, or in the `docker-compose.yml` file.
+
+You'll also need to add `--device /dev/video0:/dev/video0` to your `docker run`, or ensure
+it's listed in the `devices` array in your `docker-compose.yml`.
+
+If you map a video device _other_ than `/dev/video0`, you will additionally need to set an
+environment variable for `CAMERA_DEV` to match the mapped device mapping.
+
+See [container environment based configs](#container-environment-based-configs) for a full
+list of webcam configuration options configured with docker.
+
+#### Webcam Setup in OctoPrint
 
 Use the following values in the webcam & timelapse settings screen of the initial setup:
 
@@ -32,7 +57,7 @@ Use the following values in the webcam & timelapse settings screen of the initia
 | Snapshot URL |  `http://localhost:8080/?action=snapshot` |
 | Path to FFMPEG | `/usr/bin/ffmpeg` |
 
-### Container Environment based configs
+#### Container Environment based configs
 
 There are configuration values that you pass using container `--environment` options.
 Listed below are the options and their defaults. These are implicit in example [docker-compose.yml](docker-compose.yml),

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ launch of OctoPrint using docker.
 #### Enabling Webcam Support with Docker
 
 In order to use the webcam, you'll need to make sure the webcam service is enabled. 
-This is done by setting the environment variable `ENABLE_MJPEG_STREAMER=true` in your
+This is done by setting the environment variable `ENABLE_MJPG_STREAMER=true` in your
 `docker run` command, or in the `docker-compose.yml` file.
 
 You'll also need to add `--device /dev/video0:/dev/video0` to your `docker run`, or ensure
@@ -66,11 +66,11 @@ and if you wish to change them, refer to the docker-compose docs on setting envi
 | variable | default |
 | -------- | ------- |
 | `CAMERA_DEV` | `/dev/video0` (see [note](#devices_note)) |
-| `MJPEG_STREAMER_INPUT` | `-y -n -r 640x48` |
-| `ENABLE_MJPEG_STREAMER` | `false` |
+| `MJPG_STREAMER_INPUT` | `-y -n -r 640x48` |
+| `ENABLE_MJPG_STREAMER` | `false` |
 
 **note:** You will still need to declare the `device` mapping in your docker-compose file or docker command,
-even if you explicitly declare the `CAMERA_DEV`.  The value of `CAMERA_DEV` is used in starting the mjpeg-streamer
+even if you explicitly declare the `CAMERA_DEV`.  The value of `CAMERA_DEV` is used in starting the mjpg-streamer
 service, whereas the `devices` mapping is used by docker to make sure the container has access to the device.
 
 For example, if you change the `CAMERA_DEV` to be `/dev/video1`, you would also need to map `/dev/video1:/dev/video1`
@@ -110,7 +110,7 @@ on the host, and then start your container:
 
 ```
 docker volume create octoprint
-docker run -d -v octoprint:/octoprint --device /dev/ttyACM0:/dev/ttyACM0 --device /dev/video0:/dev/video0 -e ENABLE_MJPEG_STREAMER=true -p 80:80 --name octoprint octoprint/octoprint
+docker run -d -v octoprint:/octoprint --device /dev/ttyACM0:/dev/ttyACM0 --device /dev/video0:/dev/video0 -e ENABLE_MJPG_STREAMER=true -p 80:80 --name octoprint octoprint/octoprint
 ```
 
 [code-server]: https://github.com/cdr/code-server

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ launch of OctoPrint using docker.
 #### Enabling Webcam Support with Docker
 
 In order to use the webcam, you'll need to make sure the webcam service is enabled. 
-This is done by setting the environment variable `MJPEG_STREAMER_AUTOSTART=true` in your
+This is done by setting the environment variable `ENABLE_MJPEG_STREAMER=true` in your
 `docker run` command, or in the `docker-compose.yml` file.
 
 You'll also need to add `--device /dev/video0:/dev/video0` to your `docker run`, or ensure
@@ -67,7 +67,7 @@ and if you wish to change them, refer to the docker-compose docs on setting envi
 | -------- | ------- |
 | `CAMERA_DEV` | `/dev/video0` (see [note](#devices_note)) |
 | `MJPEG_STREAMER_INPUT` | `-y -n -r 640x48` |
-| `MJPEG_STREAMER_AUTOSTART` | `false` |
+| `ENABLE_MJPEG_STREAMER` | `false` |
 
 **note:** You will still need to declare the `device` mapping in your docker-compose file or docker command,
 even if you explicitly declare the `CAMERA_DEV`.  The value of `CAMERA_DEV` is used in starting the mjpeg-streamer
@@ -110,7 +110,7 @@ on the host, and then start your container:
 
 ```
 docker volume create octoprint
-docker run -d -v octoprint:/octoprint --device /dev/ttyACM0:/dev/ttyACM0 --device /dev/video0:/dev/video0 -e MJPEG_STREAMER_AUTOSTART=true -p 80:80 --name octoprint octoprint/octoprint
+docker run -d -v octoprint:/octoprint --device /dev/ttyACM0:/dev/ttyACM0 --device /dev/video0:/dev/video0 -e ENABLE_MJPEG_STREAMER=true -p 80:80 --name octoprint octoprint/octoprint
 ```
 
 [code-server]: https://github.com/cdr/code-server

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ and if you wish to change them, refer to the docker-compose docs on setting envi
 | -------- | ------- |
 | `CAMERA_DEV` | `/dev/video0` (see [note](#devices_note)) |
 | `MJPEG_STREAMER_INPUT` | `-y -n -r 640x48` |
+| `MJPEG_STREAMER_AUTOSTART` | `false` |
 
 **note:** You will still need to declare the `device` mapping in your docker-compose file or docker command,
 even if you explicitly declare the `CAMERA_DEV`.  The value of `CAMERA_DEV` is used in starting the mjpeg-streamer

--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ on the host, and then start your container:
 
 ```
 docker volume create octoprint
-docker run -d -v octoprint:/octoprint --device /dev/ttyACM0:/dev/ttyACM0 --device /dev/video0:/dev/video0 -p 80:80 --name octoprint octoprint/octoprint
-
+docker run -d -v octoprint:/octoprint --device /dev/ttyACM0:/dev/ttyACM0 --device /dev/video0:/dev/video0 -e MJPEG_STREAMER_AUTOSTART=true -p 80:80 --name octoprint octoprint/octoprint
 ```
 
 [code-server]: https://github.com/cdr/code-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     # uncomment the lines below to ensure camera streaming is enabled when
     # you add a video device
     #environment:
-    #  - ENABLE_MJPEG_STREAMER=true
+    #  - ENABLE_MJPG_STREAMER=true
   
   ####
   # uncomment if you wish to edit the configuration files of octoprint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     # uncomment the lines below to ensure camera streaming is enabled when
     # you add a video device
     #environment:
-    #  - MJPEG_STREAMER_AUTOSTART=true
+    #  - ENABLE_MJPEG_STREAMER=true
   
   ####
   # uncomment if you wish to edit the configuration files of octoprint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,10 @@ services:
     # - /dev/video0:/dev/video0
     volumes:
      - octoprint:/octoprint
+    # uncomment the lines below to ensure camera streaming is enabled when
+    # you add a video device
+    #environment:
+    #  - MJPEG_STREAMER_AUTOSTART=true
   
   ####
   # uncomment if you wish to edit the configuration files of octoprint

--- a/root/etc/cont-init.d/01-mjpeg-streamer-config
+++ b/root/etc/cont-init.d/01-mjpeg-streamer-config
@@ -1,13 +1,8 @@
 #!/usr/bin/with-contenv bash
 
+: "${ENABLE_MJPEG_STREAMER:=false}"
 
-# disable mjpg-streamer service
+# disable mjpg-streamer service if not enabled
 if ! $ENABLE_MJPEG_STREAMER; then
-  if [ -d /etc/disabled.services.d/mjpg-streamer ]; then
-    echo " - INFO - ==> mjpg-streamer service disabled"
-  else
-    echo " - INFO - ==> disabling mjpg-streamer service"
-    mv /etc/services.d/mjpg-streamer /etc/disabled.services.d
-    echo " - INFO - ==> disable mjpg-streamer success"
-  fi
+  rm -rf /etc/services.d/mjpg-streamer
 fi

--- a/root/etc/cont-init.d/01-mjpeg-streamer-config
+++ b/root/etc/cont-init.d/01-mjpeg-streamer-config
@@ -5,7 +5,7 @@ DISABLED_SERVICES_DIR=/etc/disabled.services.d
 
 # disable mjpg-streamer service
 if ! $ENABLE_MJPEG_STREAMER; then
-  if [ -d "${DISABLED_SERVICES_DIR}/mjpg-streamer"]; then
+  if [ -d $DISABLED_SERVICES_DIR/mjpg-streamer ]; then
     echo " - INFO - ==> mjpg-streamer service disabled"
   else
     echo " - INFO - ==> disabling mjpg-streamer service"
@@ -14,7 +14,7 @@ if ! $ENABLE_MJPEG_STREAMER; then
   fi
 else
   # allow user to re-enable
-  if [ ! -d "/etc/services.d/mjpg-streamer" ] && [ -d "${DISABLED_SERVICES_DIR}/mjpg-streamer" ]; then
+  if [ ! -d /etc/services.d/mjpg-streamer ] && [ -d $DISABLED_SERVICES_DIR/mjpg-streamer ]; then
     echo " - INFO - ==> re-enabling mjpg-streamer service"
     mv $DISABLED_SERVICES_DIR/mjpg-streamer /etc/services.d/mjpg-streamer
     echo " - INFO - ==> enable mjpg-streamer service ok"

--- a/root/etc/cont-init.d/01-mjpeg-streamer-config
+++ b/root/etc/cont-init.d/01-mjpeg-streamer-config
@@ -1,9 +1,16 @@
 #!/usr/bin/with-contenv bash
 
+DISABLED_SERVICES_DIR=/etc/disabled.services.d
 : "${ENABLE_MJPEG_STREAMER:=false}"
+
 if ! $ENABLE_MJPEG_STREAMER; then
-  echo "disabling mjpeg-streamer"
-  mv /etc/services.d/mjpg-streamer /etc/disabled.services.d
+  if [ -d "${DISABLED_SERVICES_DIR}/mjpg-streamer"]; then
+    echo " - INFO - ==> mjpg-streamer service disabled"
+  else
+    echo " - INFO - ==> disabling mjpg-streamer service"
+    mv /etc/services.d/mjpg-streamer $DISABLED_SERVICES_DIR
+    echo " - INFO - ==> disable mjpg-streamer success"
+  fi
 else
-  echo "mjpeg-streamer service enabled..."
+  echo " - INFO - ==> mjpeg-streamer service enabled..."
 fi

--- a/root/etc/cont-init.d/01-mjpeg-streamer-config
+++ b/root/etc/cont-init.d/01-mjpeg-streamer-config
@@ -3,6 +3,7 @@
 DISABLED_SERVICES_DIR=/etc/disabled.services.d
 : "${ENABLE_MJPEG_STREAMER:=false}"
 
+# disable mjpg-streamer service
 if ! $ENABLE_MJPEG_STREAMER; then
   if [ -d "${DISABLED_SERVICES_DIR}/mjpg-streamer"]; then
     echo " - INFO - ==> mjpg-streamer service disabled"
@@ -12,5 +13,12 @@ if ! $ENABLE_MJPEG_STREAMER; then
     echo " - INFO - ==> disable mjpg-streamer success"
   fi
 else
-  echo " - INFO - ==> mjpeg-streamer service enabled..."
+  # allow user to re-enable
+  if [ ! -d "/etc/services.d/mjpg-streamer" ] && [ -d "${DISABLED_SERVICES_DIR}/mjpg-streamer" ]; then
+    echo " - INFO - ==> re-enabling mjpg-streamer service"
+    mv $DISABLED_SERVICES_DIR/mjpg-streamer /etc/services.d/mjpg-streamer
+    echo " - INFO - ==> enable mjpg-streamer service ok"
+  else 
+    echo " - INFO - ==> mjpeg-streamer service enabled"
+  fi
 fi

--- a/root/etc/cont-init.d/01-mjpeg-streamer-config
+++ b/root/etc/cont-init.d/01-mjpeg-streamer-config
@@ -1,24 +1,13 @@
 #!/usr/bin/with-contenv bash
 
-DISABLED_SERVICES_DIR=/etc/disabled.services.d
-: "${ENABLE_MJPEG_STREAMER:=false}"
 
 # disable mjpg-streamer service
 if ! $ENABLE_MJPEG_STREAMER; then
-  if [ -d $DISABLED_SERVICES_DIR/mjpg-streamer ]; then
+  if [ -d /etc/disabled.services.d/mjpg-streamer ]; then
     echo " - INFO - ==> mjpg-streamer service disabled"
   else
     echo " - INFO - ==> disabling mjpg-streamer service"
-    mv /etc/services.d/mjpg-streamer $DISABLED_SERVICES_DIR
+    mv /etc/services.d/mjpg-streamer /etc/disabled.services.d
     echo " - INFO - ==> disable mjpg-streamer success"
-  fi
-else
-  # allow user to re-enable
-  if [ ! -d /etc/services.d/mjpg-streamer ] && [ -d $DISABLED_SERVICES_DIR/mjpg-streamer ]; then
-    echo " - INFO - ==> re-enabling mjpg-streamer service"
-    mv $DISABLED_SERVICES_DIR/mjpg-streamer /etc/services.d/mjpg-streamer
-    echo " - INFO - ==> enable mjpg-streamer service ok"
-  else 
-    echo " - INFO - ==> mjpeg-streamer service enabled"
   fi
 fi

--- a/root/etc/cont-init.d/01-mjpeg-streamer-config
+++ b/root/etc/cont-init.d/01-mjpeg-streamer-config
@@ -1,9 +1,9 @@
 #!/usr/bin/with-contenv bash
 
-ENABLE_MJPEG_STREAMER=${MJPEG_STREAMER_AUTOSTART:=false}
+: "${ENABLE_MJPEG_STREAMER:=false}"
 if ! $ENABLE_MJPEG_STREAMER; then
   echo "disabling mjpeg-streamer"
-  rm -rf /etc/services.d/mjpeg-streamer
+  mv /etc/services.d/mjpeg-streamer /etc/disabled.services.d
 else
   echo "mjpeg-streamer service enabled..."
 fi

--- a/root/etc/cont-init.d/01-mjpeg-streamer-config
+++ b/root/etc/cont-init.d/01-mjpeg-streamer-config
@@ -1,0 +1,9 @@
+#!/usr/bin/with-contenv bash
+
+ENABLE_MJPEG_STREAMER=${MJPEG_STREAMER_AUTOSTART:=false}
+if ! $ENABLE_MJPEG_STREAMER; then
+  echo "disabling mjpeg-streamer"
+  rm -rf /etc/services.d/mjpeg-streamer
+else
+  echo "mjpeg-streamer service enabled..."
+fi

--- a/root/etc/cont-init.d/01-mjpeg-streamer-config
+++ b/root/etc/cont-init.d/01-mjpeg-streamer-config
@@ -3,7 +3,7 @@
 : "${ENABLE_MJPEG_STREAMER:=false}"
 if ! $ENABLE_MJPEG_STREAMER; then
   echo "disabling mjpeg-streamer"
-  mv /etc/services.d/mjpeg-streamer /etc/disabled.services.d
+  mv /etc/services.d/mjpg-streamer /etc/disabled.services.d
 else
   echo "mjpeg-streamer service enabled..."
 fi

--- a/root/etc/cont-init.d/01-mjpg-streamer-config
+++ b/root/etc/cont-init.d/01-mjpg-streamer-config
@@ -1,8 +1,8 @@
 #!/usr/bin/with-contenv bash
 
-: "${ENABLE_MJPEG_STREAMER:=false}"
+: "${ENABLE_MJPG_STREAMER:=false}"
 
 # disable mjpg-streamer service if not enabled
-if ! $ENABLE_MJPEG_STREAMER; then
+if ! $ENABLE_MJPG_STREAMER; then
   rm -rf /etc/services.d/mjpg-streamer
 fi

--- a/root/etc/services.d/mjpg-streamer/run
+++ b/root/etc/services.d/mjpg-streamer/run
@@ -1,15 +1,15 @@
 #!/usr/bin/with-contenv sh
 
-if [ -n "$STREAMER_FLAGS" ]; then
-  echo "Deprecation warning: the environment variable '\$STREAMER_FLAGS' was renamed to '\$MJPEG_STREAMER_INPUT'"
+if [ -n "$MJPEG_STREAMER_INPUT" ]; then
+  echo "Deprecation warning: the environment variable '\$MJPEG_STREAMER_INPUT' was renamed to '\$MJPG_STREAMER_INPUT'"
 
-  MJPEG_STREAMER_INPUT=$STREAMER_FLAGS
+  MJPG_STREAMER_INPUT=$MJPEG_STREAMER_INPUT
 fi
 
-if ! expr "$MJPEG_STREAMER_INPUT" : ".*\.so.*" > /dev/null; then
-  MJPEG_STREAMER_INPUT="input_uvc.so $MJPEG_STREAMER_INPUT"
+if ! expr "$MJPG_STREAMER_INPUT" : ".*\.so.*" > /dev/null; then
+  MJPG_STREAMER_INPUT="input_uvc.so $MJPG_STREAMER_INPUT"
 fi
 
 exec mjpg_streamer \
-  -i "/usr/local/lib/mjpg-streamer/$MJPEG_STREAMER_INPUT -d $CAMERA_DEV" \
+  -i "/usr/local/lib/mjpg-streamer/$MJPG_STREAMER_INPUT -d $CAMERA_DEV" \
   -o "/usr/local/lib/mjpg-streamer/output_http.so -w /usr/local/share/mjpg-streamer/www -p 8080"


### PR DESCRIPTION
**BREAKING CHANGES** (mjpg-streamer will no longer be started by default, user will need to pass `ENABLE_MJPG_STREAMER` to start this service with the container)

- deprecated `MJPEG_STREAMER_INPUT` in favor of `MJPG_STREAMER_INPUT`
- makes usage of `mjpg-streamer` consistent (changed all `mjpeg` usages to `mjpg`
- makes the mjpg-streamer service optional (defaults to false) 

closes #84 