### PR TITLE
Fix image deploy workflow

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -1,5 +1,5 @@
-main_image_files:
+main:
   - 'Dockerfile'
   - 'root/**'
-minimal_image_files:
+minimal:
   - 'minimal/**'

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -18,7 +18,7 @@ jobs:
       minimal: ${{ steps.filter.outputs.minimal }}
     steps:
     - uses: actions/checkout@v2
-    - uses: dorny/paths-filter@v2.2.1
+    - uses: dorny/paths-filter@v2.5.0
       id: filter
       with:
         filters: '.github/filters.yml'

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -14,20 +14,19 @@ jobs:
   filters:
     runs-on: ubuntu-latest
     outputs:
-      found_main_image_changes: ${{ steps.filter.outputs.main_image_files }}
-      found_minimal_image_changes: ${{ steps.filter.outputs.minimal_image_files }}
+      main: ${{ steps.filter.outputs.main }}
+      minimal: ${{ steps.filter.outputs.minimal }}
     steps:
     - uses: actions/checkout@v2
     - uses: dorny/paths-filter@v2.2.1
-      if: ${{ github.event_name == 'push'}}
       id: filter
       with:
         filters: '.github/filters.yml'
 
-  release:
+  release_main:
     runs-on: ubuntu-latest
     needs: filters
-    if: ${{ github.event_name == 'repository_dispatch' || needs.filters.outputs.found_main_changes == 'true' }}
+    if: needs.filters.outputs.main == 'true'
     strategy:
       matrix:
         tags: ['latest','%X%', '%X.Y%', '%X.Y.Z%']


### PR DESCRIPTION
- removes use of _files in filter names since that is now used in dory/paths-filter
- removed `if` logic of `filters` job since that is what the `on` is for
  - note: this was previously programmed with incorrect logic, basically causing the trigger for `release_main` to never run on release or push to master