### PR TITLE
Update usage set env in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,9 @@ jobs:
         uses: docker/setup-qemu-action@v1
         with:
           platforms: arm,arm64
+      -
+        name: Set up Buildx
+        uses: docker/setup-buildx-action@v1
       - 
         name: Run a Test Build
         id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,46 +12,51 @@ jobs:
   filters:
     runs-on: ubuntu-latest
     outputs:
-      found_main_changes: ${{ steps.filter.outputs.main_image_files }}
-      found_minimal_changes: ${{ steps.filter.outputs.minimal_image_files }}
+      main: ${{ steps.filter.outputs.main }}
+      minimal: ${{ steps.filter.outputs.minimal }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: dorny/paths-filter@v2.2.1
-      id: filter
-      with:
-        filters: '.github/filters.yml'
+      - 
+        uses: actions/checkout@v2
+      - 
+        uses: dorny/paths-filter@v2.5.0
+        id: filter
+        with:
+          filters: '.github/filters.yml'
 
   docker_build:
     runs-on: ubuntu-latest
     needs: filters
-    if: ${{ needs.filters.outputs.found_main_changes == 'true' }}
+    if: ${{ needs.filters.outputs.main == 'true' }}
     
     steps:
-      - uses: actions/checkout@v2
-      - name: Get OctoPrint Stable
-        id: get-octoprint-release
+      - 
+        uses: actions/checkout@v2
+      - 
+        name: Get OctoPrint Stable
+        id: latest-octoprint
         uses: pozetroninc/github-action-get-latest-release@master
         with:
           owner: OctoPrint
           repo: OctoPrint
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
+          excludes: prerelease,draft
+      - 
+        name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
         with:
-          buildx-version: latest
-          qemu-version: latest
-      - name: Docker login
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
-      - name: Build Image
+          platforms: arm,arm64
+      - 
+        name: Run a Test Build
         id: build
-        run: |
-          docker buildx build --push \
-            --platform linux/arm64,linux/amd64,linux/arm/v7 \
-            --cache-from octoprint/octoprint:cache \
-            --cache-to octoprint/octoprint:cache \
-            --build-arg tag=${{ steps.get-octoprint-release.outputs.release }} \
-            --progress plain -t octoprint/octoprint:ci -f Dockerfile .
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          cache-from: type=registry,ref=octoprint/octoprint:cache
+          cache-to: type=inline
+          platforms: |
+            linux/amd64
+            linux/arm/v7
+            linux/arm64
+          build-args: |
+            octoprint_ref=${{ steps.latest-octoprint.outputs.release }}
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,14 +48,22 @@ jobs:
       -
         name: Set up Buildx
         uses: docker/setup-buildx-action@v1
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashfiles('**/Dockerfile') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
       - 
         name: Run a Test Build
         id: build
         uses: docker/build-push-action@v2
         with:
           push: false
-          cache-from: type=registry,ref=octoprint/octoprint:cache
-          cache-to: type=inline
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
           platforms: |
             linux/amd64
             linux/arm/v7

--- a/.github/workflows/manual-repo-dispatch.yml
+++ b/.github/workflows/manual-repo-dispatch.yml
@@ -19,5 +19,5 @@ jobs:
         with:
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
           repository: ${{ github.repository }}
-          event-type: 'release'
+          event-type: 'deploy'
           client-payload: '{"tag_name": "${{ github.event.inputs.version }}"}'

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -1,4 +1,4 @@
-name: Image Deploy
+name: Deploy Images
 
 on:
   repository_dispatch:
@@ -48,7 +48,14 @@ jobs:
       -
         name: Set up Buildx
         uses: docker/setup-buildx-action@v1
-
+      -
+        name: Cache Docker Layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashfiles('**/Dockerfile') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
       -
         name: Tagging Strategy
         id: tagging
@@ -74,8 +81,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          cache-from: type=registry,ref=octoprint/octoprint:cache
-          cache-to: type=registry,ref=octoprint/octoprint:cache
+          cache-from: type=local,ref=src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
           tags: ${{ steps.tagging.outputs.tags }}
           platforms: |
             linux/amd64
@@ -132,6 +139,14 @@ jobs:
         name: Set up Buildx
         uses: docker/setup-buildx-action@v1
       -
+        name: Cache Docker Layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashfiles('**/Dockerfile') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
         name: Tagging Strategy
         id: tagging
         uses: HackerHappyHour/tagging-strategy@2.0.0-rc2
@@ -156,8 +171,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          cache-from: type=registry,ref=octoprint/octoprint:cache
-          cache-to: type=registry,ref=octoprint/octoprint:cache
+          cache-from: type=local,ref=src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
           tags: ${{ steps.tagging.outputs.tags }}
           platforms: |
             linux/amd64

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -40,7 +40,7 @@ jobs:
   # should not publish the 'latest' tag unless the given tag from payload is 
   # equal to the latest (stable) release tag of octoprint
   release_main_on_dispatch:
-    if: github.event_name != 'push' && github.repository_owner == 'OctoPrint'
+    if: github.event_name == 'repository_dispatch' && github.repository_owner == 'OctoPrint'
     needs: filters
 
     runs-on: ubuntu-latest
@@ -83,7 +83,7 @@ jobs:
           push: true
           cache-from: octoprint/octoprint:cache
           cache-to: octoprint/octoprint:cache
-          tags: ${{ steps.tagg }}
+          tags: ${{ steps.tagging.outputs.tags }}
           platforms: |
             linux/amd64
             linux/arm/v7
@@ -98,7 +98,7 @@ jobs:
   # ensures this will not run on the dispatch event, or when non-relevant files
   # are changed (such as documentation or build/workflow scripts)
   release_main_on_push:
-    if: needs.filters.outputs.main == 'true' && github.event_name == 'push' && needs.filters.outputs.repo_org == 'OctoPrint'
+    if: needs.filters.outputs.main == 'true' && github.event_name == 'push' && github.repository_owner == 'OctoPrint'
     needs: filters
 
     runs-on: ubuntu-latest

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -8,6 +8,17 @@ on:
       - master
       
 jobs:
+  meta:
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.metadata.outputs.labels }}
+    steps:
+      - 
+        id: metadata
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: octoprint/octoprint
+
   # this job should build and publish the main octoprint image for the given tag, but
   # should not publish the 'latest' tag unless the given tag from payload is 
   # equal to the latest (stable) release tag of octoprint
@@ -68,6 +79,8 @@ jobs:
             linux/arm64
           build-args: |
             octoprint_ref=${{ github.event.client_payload.tag_name }}
+          labels: ${{ needs.meta.outputs.labels }}
+
 
 
   push_filters:
@@ -148,3 +161,4 @@ jobs:
             linux/arm64
           build-args: |
             octoprint_ref=${{ steps.latest-octoprint.outputs.release }}
+          labels: ${{ needs.meta.outputs.labels }}

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -81,8 +81,8 @@ jobs:
         if: steps.tagging.outputs.tag == 'latest' && needs.filters.outputs.stable_octoprint != github.event.client_payload.tag_name
         with:
           push: true
-          cache-from: octoprint/octoprint:cache
-          cache-to: octoprint/octoprint:cache
+          cache-from: type=registry,ref=octoprint/octoprint:cache
+          cache-to: type=inline
           tags: ${{ steps.tagging.outputs.tags }}
           platforms: |
             linux/amd64
@@ -139,8 +139,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          cache-from: octoprint/octoprint:cache
-          cache-to: octoprint/octoprint:cache
+          cache-from: type=registry,ref=octoprint/octoprint:cache
+          cache-to: type=inline
           tags: ${{ steps.tagging.outputs.tags }}
           platforms: |
             linux/amd64

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           push: true
           cache-from: type=registry,ref=octoprint/octoprint:cache
-          cache-to: type=inline
+          cache-to: type=registry,ref=octoprint/octoprint:cache
           tags: ${{ steps.tagging.outputs.tags }}
           platforms: |
             linux/amd64
@@ -140,7 +140,7 @@ jobs:
         with:
           push: true
           cache-from: type=registry,ref=octoprint/octoprint:cache
-          cache-to: type=inline
+          cache-to: type=registry,ref=octoprint/octoprint:cache
           tags: ${{ steps.tagging.outputs.tags }}
           platforms: |
             linux/amd64

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -58,8 +58,6 @@ jobs:
 
       - name: Build and Deploy
         uses: docker/build-push-action@v2
-        # make sure not to publish 'latest' if tag is a pre-release or not the latest stable octoprint release
-        if: steps.tagging.outputs.tag == 'latest' && needs.filters.outputs.stable_octoprint != github.event.client_payload.tag_name
         with:
           push: true
           cache-from: type=registry,ref=octoprint/octoprint:cache

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -45,7 +45,7 @@ jobs:
   # should not publish the 'latest' tag unless the given tag from payload is 
   # equal to the latest (stable) release tag of octoprint
   release_main_on_dispatch:
-    if: github.event_name != 'push' && needs.filters.outputs.repo_org = 'OctoPrint'
+    if: github.event_name != 'push' && needs.filters.outputs.repo_org == 'OctoPrint'
     needs: filters
 
     runs-on: ubuntu-latest
@@ -93,7 +93,7 @@ jobs:
   # ensures this will not run on the dispatch event, or when non-relevant files
   # are changed (such as documentation or build/workflow scripts)
   release_main_on_push:
-    if: needs.filters.outputs.main == 'true' && github.event_name == 'push'
+    if: needs.filters.outputs.main == 'true' && github.event_name == 'push' && needs.filters.outputs.repo_org == 'OctoPrint'
     needs: filters
 
     runs-on: ubuntu-latest

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -2,9 +2,7 @@ name: Image Deploy
 
 on:
   repository_dispatch:
-    types:
-      - released
-      - prereleased
+    types: [deploy, released, prereleased]
   push:
     branches:
       - master
@@ -40,6 +38,7 @@ jobs:
   # should not publish the 'latest' tag unless the given tag from payload is 
   # equal to the latest (stable) release tag of octoprint
   release_main_on_dispatch:
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     needs: filters
     strategy:
@@ -84,11 +83,11 @@ jobs:
   # This job should build and publish the main octoprint image from the latest,
   # stable release of octoprint, and *should* overwrite the 'latest' tag
   release_main_on_push:
-    runs-on: ubuntu-latest
-    needs: filters
     # ensures this will not run on the dispatch event, or when non-relevant files
     # are changed (such as documentation or build/workflow scripts)
     if: needs.filters.outputs.main == 'true' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: filters
     strategy:
       matrix:
         tags: ['latest','%X%', '%X.Y%', '%X.Y.Z%']

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -56,15 +56,17 @@ jobs:
           platforms: arm,arm64
 
       -
-        name: Docker Meta
-        id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        name: Tagging Strategy
+        id: tagging
+        uses: HackerHappyHour/tagging-strategy@2.0.0-rc2
         with:
-          images: octprint/octoprint
-          tag-semver: |
-            {{major}}
-            {{major}}.{{minor}}
-            {{major}}.{{minor}}.{{patch}}
+          image_name: octprint/octoprint
+          latest: ${{ github.event.client_payload.tag_name == needs.filters.outputs.stable_octoprint }}
+          tag_name: ${{ github.event.client_payload.tag_name }}
+          tags: |
+            %X%
+            %X.Y%
+            %X.Y.Z%
 
       - 
         name: Login to DockerHub
@@ -81,21 +83,13 @@ jobs:
           push: true
           cache-from: octoprint/octoprint:cache
           cache-to: octoprint/octoprint:cache
-          tags: |
-            ${{}}
+          tags: ${{ steps.tagg }}
           platforms: |
             linux/amd64
             linux/arm/v7
             linux/arm64
           build-args: |
-            octoprint_ref=${{  }}
-        run: |
-          docker buildx build --push \
-            --platform linux/arm64,linux/amd64,linux/arm/v7 \
-            --cache-from octoprint/octoprint:cache \
-            --cache-to octoprint/octoprint:cache \
-            --build-arg tag=${{ env.tag_name }} \
-            --progress plain -t octoprint/octoprint:${{ steps.tagging.outputs.tag }} -f Dockerfile .
+            octoprint_ref=${{ github.event.client_payload.tag_name }}
 
 
 
@@ -108,43 +102,49 @@ jobs:
     needs: filters
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        tags: ['latest','%X%', '%X.Y%', '%X.Y.Z%']
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set Tag
-        run: echo "::set-output name=tag_name::${{ needs.filters.outputs.stable_octoprint }}"
-      - name: Tagging strategy
+      - 
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm,arm64
+
+      -
+        name: Tagging Strategy
         id: tagging
-        uses: HackerHappyHour/tagging-strategy@1.0.0
+        uses: HackerHappyHour/tagging-strategy@2.0.0-rc2
         with:
-          tag_name: ${{ env.tag_name }}
-          pattern: ${{ matrix.tags}}
+          image_name: octprint/octoprint
+          latest: true
+          tag_name: ${{ needs.filters.outputs.stable_octoprint }}
+          tags: |
+            %X%
+            %X.Y%
+            %X.Y.Z%
 
-      - name: Set up Docker Buildx
-        id: setup
-        uses: crazy-max/ghaction-docker-buildx@v3
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
-          buildx-version: latest
-          qemu-version: latest
-      
-      - name: Docker Login
-        id: login
-        run: |
-          echo ${{ secrets.DOCKER_PASSWORD}} | docker login -u ${{ secrets.DOCKER_USERNAME}} --password-stdin
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and Deploy
+      - 
+        name: Build and Deploy
         id: build_deploy
-        #if matrix tag is latest AND tag_name is NOT equal to latest-octoprint don't build
-        # this allows rebuilds of older versions without changing 'latest' to an old release
-        if: ${{!(env.tag_name == 'latest' && ( steps.latest-octprint.outputs.release != env.tag_name ))}}
-        run: |
-          docker buildx build --push \
-            --platform linux/arm64,linux/amd64,linux/arm/v7 \
-            --cache-from octoprint/octoprint:cache \
-            --cache-to octoprint/octoprint:cache \
-            --build-arg tag=${{ env.tag_name }} \
-            --progress plain -t octoprint/octoprint:${{ steps.tagging.outputs.tag }} -f Dockerfile .
-
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          cache-from: octoprint/octoprint:cache
+          cache-to: octoprint/octoprint:cache
+          tags: ${{ steps.tagging.outputs.tags }}
+          platforms: |
+            linux/amd64
+            linux/arm/v7
+            linux/arm64
+          build-args: |
+            octoprint_ref=${{ needs.filters.outputs.stable_octoprint }}

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -7,35 +7,7 @@ on:
     branches:
       - master
       
-# This job creates filters and configurations that are used by the release jobs
-# any shared configuration/conditionals should be set as outputs for this job
-# or be present in the output of one of this jobs steps
 jobs:
-  filters:
-    runs-on: ubuntu-latest
-    outputs:
-      main: ${{ steps.filter.outputs.main }}
-      minimal: ${{ steps.filter.outputs.minimal }}
-      stable_octoprint: ${{ steps.latest-octprint.outputs.release }}
-
-    steps:
-    - uses: actions/checkout@v2
-
-    # outputs: release
-    - name: Get latest Octoprint
-      id: latest-octoprint
-      uses: pozetroninc/github-action-get-latest-release@master
-      with:
-        owner: OctoPrint
-        repo: OctoPrint
-
-    # outputs: (loaded from file specified in filters)
-    - uses: dorny/paths-filter@v2.5.0
-      id: filter
-      with:
-        filters: '.github/filters.yml'
-
-
   # this job should build and publish the main octoprint image for the given tag, but
   # should not publish the 'latest' tag unless the given tag from payload is 
   # equal to the latest (stable) release tag of octoprint
@@ -48,6 +20,14 @@ jobs:
     steps:
       - 
         uses: actions/checkout@v2
+      - 
+        name: Get latest Octoprint
+        id: latest-octoprint
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          owner: OctoPrint
+          repo: OctoPrint
+          excludes: draft
       -
         name: Set up QEMU
         id: qemu
@@ -61,7 +41,8 @@ jobs:
         uses: HackerHappyHour/tagging-strategy@2.0.0-rc2
         with:
           image_name: octprint/octoprint
-          latest: ${{ github.event.client_payload.tag_name == needs.filters.outputs.stable_octoprint }}
+          # allows the publishing of pre-release images by turning 'latest' to false if the 
+          latest: ${{ github.event.action == 'released' }}
           tag_name: ${{ github.event.client_payload.tag_name }}
           tags: |
             %X%
@@ -106,6 +87,19 @@ jobs:
     steps:
       - 
         uses: actions/checkout@v2
+      # outputs: (loaded from file specified in filters)
+      - uses: dorny/paths-filter@v2.5.0
+        id: filter
+        with:
+          filters: '.github/filters.yml'
+        # outputs: release
+      - name: Get latest Octoprint
+        id: latest-octoprint
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          owner: OctoPrint
+          repo: OctoPrint
+          excludes: prerelease,draft
       -
         name: Set up QEMU
         id: qemu

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -24,6 +24,7 @@ jobs:
   # equal to the latest (stable) release tag of octoprint
   release_main_on_dispatch:
     if: github.event_name == 'repository_dispatch' && github.repository_owner == 'OctoPrint'
+    needs: meta
 
     runs-on: ubuntu-latest
     
@@ -44,6 +45,9 @@ jobs:
         uses: docker/setup-qemu-action@v1
         with:
           platforms: arm,arm64
+      -
+        name: Set up Buildx
+        uses: docker/setup-buildx-action@v1
 
       -
         name: Tagging Strategy
@@ -103,14 +107,13 @@ jobs:
   # are changed (such as documentation or build/workflow scripts)
   release_main_on_push:
     if: needs.push_filters.outputs.main == 'true' && github.event_name == 'push' && github.repository_owner == 'OctoPrint'
-    needs: filters
+    needs: [meta, push_filters]
 
     runs-on: ubuntu-latest
 
     steps:
       - 
         uses: actions/checkout@v2
-
       # outputs: release
       - name: Get latest Octoprint
         id: latest-octoprint
@@ -125,7 +128,9 @@ jobs:
         uses: docker/setup-qemu-action@v1
         with:
           platforms: arm,arm64
-
+      -
+        name: Set up Buildx
+        uses: docker/setup-buildx-action@v1
       -
         name: Tagging Strategy
         id: tagging
@@ -138,7 +143,6 @@ jobs:
             %X%
             %X.Y%
             %X.Y.Z%
-
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -81,7 +81,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          cache-from: type=local,ref=src=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
           tags: ${{ steps.tagging.outputs.tags }}
           platforms: |
@@ -171,7 +171,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          cache-from: type=local,ref=src=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
           tags: ${{ steps.tagging.outputs.tags }}
           platforms: |

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -3,54 +3,103 @@ name: Image Deploy
 on:
   repository_dispatch:
     types:
-      - release
+      - released
+      - prereleased
   push:
     branches:
       - master
       
 jobs:
-  # This job ensures image is only deployed when files that make up the image are changed
-  # (changing docs or build scripts won't result in a push to registry)
+  # This job creates filters and configurations that are used by the release jobs
+  # any shared configuration/conditionals should be set as outputs for this job
+  # or be present in the output of one of this jobs steps
   filters:
     runs-on: ubuntu-latest
     outputs:
       main: ${{ steps.filter.outputs.main }}
       minimal: ${{ steps.filter.outputs.minimal }}
+      stable_octoprint: ${{ steps.latest-octprint.outputs.release }}
     steps:
     - uses: actions/checkout@v2
+
+    # outputs: release
+    - name: Get latest Octoprint
+      id: latest-octoprint
+      uses: pozetroninc/github-action-get-latest-release@master
+      with:
+        owner: OctoPrint
+        repo: OctoPrint
+
+    # outputs: (loaded from file specified in filters)
     - uses: dorny/paths-filter@v2.5.0
       id: filter
       with:
         filters: '.github/filters.yml'
 
-  release_main:
+  # this job should build and publish the main octoprint image for the given tag, but
+  # should not publish the 'latest' tag unless the given tag from payload is 
+  # equal to the latest (stable) release tag of octoprint
+  release_main_on_dispatch:
     runs-on: ubuntu-latest
     needs: filters
-    if: needs.filters.outputs.main == 'true' || github.event_name == 'repository_dispatch'
     strategy:
       matrix:
         tags: ['latest','%X%', '%X.Y%', '%X.Y.Z%']
-
-
+    
     steps:
       - uses: actions/checkout@v2
-      - name: Get Tag if push
-        id: latest-octoprint
-        uses: pozetroninc/github-action-get-latest-release@master
-        with:
-          owner: OctoPrint
-          repo: OctoPrint
-      - name: Set Tag on Push
-        if: ${{ github.event_name == 'push'}}
-        run: echo "::set-env name=tag_name::${{ steps.latest-octoprint.outputs.release }}"
-      - name: Set Tag on dispatch
-        if: ${{ github.event_name == 'repository_dispatch' }}
-        run: echo "::set-env name=tag_name::${{ github.event.client_payload.tag_name }}"
       - name: Tagging strategy
         id: tagging
         uses: HackerHappyHour/tagging-strategy@1.0.0
         with:
-          tag_name: "${{ env.tag_name }}"
+          tag_name: ${{ github.event.client_payload.tag_name }}
+          pattern: ${{ matrix.tags}}
+
+      - name: Set up Docker Buildx
+        id: setup
+        uses: crazy-max/ghaction-docker-buildx@v3
+        with:
+          buildx-version: latest
+          qemu-version: latest
+      
+      - name: Docker Login
+        id: login
+        run: |
+          echo ${{ secrets.DOCKER_PASSWORD}} | docker login -u ${{ secrets.DOCKER_USERNAME}} --password-stdin
+
+      - name: Build and Deploy
+        id: build_deploy
+        # make sure not to publish 'latest' if tag is a pre-release or not the latest stable octoprint release
+        if: steps.tagging.outputs.tag == 'latest' && needs.filters.outputs.stable_octoprint != github.event.client_payload.tag_name
+        run: |
+          docker buildx build --push \
+            --platform linux/arm64,linux/amd64,linux/arm/v7 \
+            --cache-from octoprint/octoprint:cache \
+            --cache-to octoprint/octoprint:cache \
+            --build-arg tag=${{ env.tag_name }} \
+            --progress plain -t octoprint/octoprint:${{ steps.tagging.outputs.tag }} -f Dockerfile .
+
+
+
+  # This job should build and publish the main octoprint image from the latest,
+  # stable release of octoprint, and *should* overwrite the 'latest' tag
+  release_main_on_push:
+    runs-on: ubuntu-latest
+    needs: filters
+    # ensures this will not run on the dispatch event, or when non-relevant files
+    # are changed (such as documentation or build/workflow scripts)
+    if: needs.filters.outputs.main == 'true' && github.event_name == 'push'
+    strategy:
+      matrix:
+        tags: ['latest','%X%', '%X.Y%', '%X.Y.Z%']
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Tagging strategy
+        id: tagging
+        uses: HackerHappyHour/tagging-strategy@1.0.0
+        with:
+          tag_name: ${{ env.tag_name }}
           pattern: "${{ matrix.tags}}"
 
       - name: Set up Docker Buildx

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -7,16 +7,17 @@ on:
     branches:
       - master
       
+# This job creates filters and configurations that are used by the release jobs
+# any shared configuration/conditionals should be set as outputs for this job
+# or be present in the output of one of this jobs steps
 jobs:
-  # This job creates filters and configurations that are used by the release jobs
-  # any shared configuration/conditionals should be set as outputs for this job
-  # or be present in the output of one of this jobs steps
   filters:
     runs-on: ubuntu-latest
     outputs:
       main: ${{ steps.filter.outputs.main }}
       minimal: ${{ steps.filter.outputs.minimal }}
       stable_octoprint: ${{ steps.latest-octprint.outputs.release }}
+      repo_org: ${{ steps.repo-org.outputs.repo_org }}
     steps:
     - uses: actions/checkout@v2
 
@@ -33,14 +34,21 @@ jobs:
       id: filter
       with:
         filters: '.github/filters.yml'
+    
+    - name: GitHub Environment Variables Action
+      id: repo-org
+      uses: FranzDiebold/github-env-vars-action@v1.2.1
+      run: echo "::set-output name=repo_org::$GITHUB_REPOSITORY_OWNER"
+
 
   # this job should build and publish the main octoprint image for the given tag, but
   # should not publish the 'latest' tag unless the given tag from payload is 
   # equal to the latest (stable) release tag of octoprint
   release_main_on_dispatch:
-    if: github.event_name != 'push'
-    runs-on: ubuntu-latest
+    if: github.event_name != 'push' && needs.filters.outputs.repo_org = 'OctoPrint'
     needs: filters
+
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         tags: ['latest','%X%', '%X.Y%', '%X.Y.Z%']
@@ -82,12 +90,13 @@ jobs:
 
   # This job should build and publish the main octoprint image from the latest,
   # stable release of octoprint, and *should* overwrite the 'latest' tag
+  # ensures this will not run on the dispatch event, or when non-relevant files
+  # are changed (such as documentation or build/workflow scripts)
   release_main_on_push:
-    # ensures this will not run on the dispatch event, or when non-relevant files
-    # are changed (such as documentation or build/workflow scripts)
     if: needs.filters.outputs.main == 'true' && github.event_name == 'push'
-    runs-on: ubuntu-latest
     needs: filters
+
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         tags: ['latest','%X%', '%X.Y%', '%X.Y.Z%']
@@ -99,7 +108,7 @@ jobs:
         uses: HackerHappyHour/tagging-strategy@1.0.0
         with:
           tag_name: ${{ env.tag_name }}
-          pattern: "${{ matrix.tags}}"
+          pattern: ${{ matrix.tags}}
 
       - name: Set up Docker Buildx
         id: setup

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -13,7 +13,6 @@ jobs:
   # equal to the latest (stable) release tag of octoprint
   release_main_on_dispatch:
     if: github.event_name == 'repository_dispatch' && github.repository_owner == 'OctoPrint'
-    needs: filters
 
     runs-on: ubuntu-latest
     
@@ -71,13 +70,26 @@ jobs:
             octoprint_ref=${{ github.event.client_payload.tag_name }}
 
 
+  push_filters:
+    runs-on: ubuntu-latest
+    outputs:
+      main: ${{ steps.filter.outputs.main }}
+      minimal: ${{ steps.filter.outputs.minimal }}
+    steps:
+      - 
+        uses: actions/checkout@v2
+      - 
+        uses: dorny/paths-filter@v2.5.0
+        id: filter
+        with:
+          filters: '.github/filters.yml'
 
   # This job should build and publish the main octoprint image from the latest,
   # stable release of octoprint, and *should* overwrite the 'latest' tag
   # ensures this will not run on the dispatch event, or when non-relevant files
   # are changed (such as documentation or build/workflow scripts)
   release_main_on_push:
-    if: needs.filters.outputs.main == 'true' && github.event_name == 'push' && github.repository_owner == 'OctoPrint'
+    if: needs.push_filters.outputs.main == 'true' && github.event_name == 'push' && github.repository_owner == 'OctoPrint'
     needs: filters
 
     runs-on: ubuntu-latest
@@ -85,12 +97,8 @@ jobs:
     steps:
       - 
         uses: actions/checkout@v2
-      # outputs: (loaded from file specified in filters)
-      - uses: dorny/paths-filter@v2.5.0
-        id: filter
-        with:
-          filters: '.github/filters.yml'
-        # outputs: release
+
+      # outputs: release
       - name: Get latest Octoprint
         id: latest-octoprint
         uses: pozetroninc/github-action-get-latest-release@master
@@ -112,7 +120,7 @@ jobs:
         with:
           image_name: octprint/octoprint
           latest: true
-          tag_name: ${{ needs.filters.outputs.stable_octoprint }}
+          tag_name: ${{ steps.latest-octoprint.outputs.release }}
           tags: |
             %X%
             %X.Y%
@@ -139,4 +147,4 @@ jobs:
             linux/arm/v7
             linux/arm64
           build-args: |
-            octoprint_ref=${{ needs.filters.outputs.stable_octoprint }}
+            octoprint_ref=${{ steps.latest-octoprint.outputs.release }}

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -17,7 +17,7 @@ jobs:
       main: ${{ steps.filter.outputs.main }}
       minimal: ${{ steps.filter.outputs.minimal }}
       stable_octoprint: ${{ steps.latest-octprint.outputs.release }}
-      repo_org: ${{ steps.repo-org.outputs.repo_org }}
+
     steps:
     - uses: actions/checkout@v2
 
@@ -34,50 +34,61 @@ jobs:
       id: filter
       with:
         filters: '.github/filters.yml'
-    
-    - name: GitHub Environment Variables Action
-      id: repo-org
-      uses: FranzDiebold/github-env-vars-action@v1.2.1
-      run: echo "::set-output name=repo_org::$GITHUB_REPOSITORY_OWNER"
 
 
   # this job should build and publish the main octoprint image for the given tag, but
   # should not publish the 'latest' tag unless the given tag from payload is 
   # equal to the latest (stable) release tag of octoprint
   release_main_on_dispatch:
-    if: github.event_name != 'push' && needs.filters.outputs.repo_org == 'OctoPrint'
+    if: github.event_name != 'push' && github.repository_owner == 'OctoPrint'
     needs: filters
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        tags: ['latest','%X%', '%X.Y%', '%X.Y.Z%']
     
     steps:
-      - uses: actions/checkout@v2
-      - name: Tagging strategy
-        id: tagging
-        uses: HackerHappyHour/tagging-strategy@1.0.0
+      - 
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
         with:
-          tag_name: ${{ github.event.client_payload.tag_name }}
-          pattern: ${{ matrix.tags}}
+          platforms: arm,arm64
 
-      - name: Set up Docker Buildx
-        id: setup
-        uses: crazy-max/ghaction-docker-buildx@v3
+      -
+        name: Docker Meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
         with:
-          buildx-version: latest
-          qemu-version: latest
-      
-      - name: Docker Login
-        id: login
-        run: |
-          echo ${{ secrets.DOCKER_PASSWORD}} | docker login -u ${{ secrets.DOCKER_USERNAME}} --password-stdin
+          images: octprint/octoprint
+          tag-semver: |
+            {{major}}
+            {{major}}.{{minor}}
+            {{major}}.{{minor}}.{{patch}}
+
+      - 
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and Deploy
-        id: build_deploy
+        uses: docker/build-push-action@v2
         # make sure not to publish 'latest' if tag is a pre-release or not the latest stable octoprint release
         if: steps.tagging.outputs.tag == 'latest' && needs.filters.outputs.stable_octoprint != github.event.client_payload.tag_name
+        with:
+          push: true
+          cache-from: octoprint/octoprint:cache
+          cache-to: octoprint/octoprint:cache
+          tags: |
+            ${{}}
+          platforms: |
+            linux/amd64
+            linux/arm/v7
+            linux/arm64
+          build-args: |
+            octoprint_ref=${{  }}
         run: |
           docker buildx build --push \
             --platform linux/arm64,linux/amd64,linux/arm/v7 \
@@ -103,6 +114,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Set Tag
+        run: echo "::set-output name=tag_name::${{ needs.filters.outputs.stable_octoprint }}"
       - name: Tagging strategy
         id: tagging
         uses: HackerHappyHour/tagging-strategy@1.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
 
 FROM python:${PYTHON_BASE_IMAGE} AS build
 
-ARG tag
-ENV tag ${tag:-master}
+ARG octoprint_ref
+ENV octoprint_ref ${octoprint_ref:-master}
 
 RUN apt-get update && apt-get install -y \
   avrdude \
@@ -50,9 +50,9 @@ RUN s6tar=$(find /tmp -name "s6-overlay-*.tar.gz") \
 
 # Install octoprint
 RUN	curl -fsSLO --compressed --retry 3 --retry-delay 10 \
-  https://github.com/OctoPrint/OctoPrint/archive/${tag}.tar.gz \
+  https://github.com/OctoPrint/OctoPrint/archive/${octoprint_ref}.tar.gz \
 	&& mkdir -p /opt/octoprint \
-  && tar xzf ${tag}.tar.gz --strip-components 1 -C /opt/octoprint --no-same-owner
+  && tar xzf ${octoprint_ref}.tar.gz --strip-components 1 -C /opt/octoprint --no-same-owner
 
 WORKDIR /opt/octoprint
 RUN pip install .

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ buildx-test:
 		--cache-from ${CACHE} \
 		--cache-to	${CACHE} \
 		--build-arg PYTHON_BASE_IMAGE=$(PYTHON_BASE_IMAGE) \
-		--build-arg tag=${OCTOPRINT_VERSION} \
+		--build-arg octoprint_ref=${OCTOPRINT_VERSION} \
 		--progress tty -t ${IMG}:ci .
 
 buildx-push:
@@ -44,7 +44,7 @@ buildx-push:
 		--cache-from ${CACHE} \
 		--cache-to	${CACHE} \
 		--build-arg PYTHON_BASE_IMAGE=$(PYTHON_BASE_IMAGE) \
-		--build-arg tag=${OCTOPRINT_VERSION} \
+		--build-arg octoprint_ref=${OCTOPRINT_VERSION} \
 		--progress plain -t ${IMG}:${IMG_TAG} .
 
 camera: 

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -35,9 +35,6 @@ RUN pip install .
 
 
 FROM python:${PYTHON_BASE_IMAGE} AS build
-LABEL description="The snappy web interface for your 3D printer"
-LABEL authors="longlivechief <chief@hackerhappyhour.com>, badsmoke <dockerhub@badcloud.eu>"
-LABEL issues="github.com/OcotPrint/docker/issues"
 
 RUN apt-get update && apt-get install -y \
   build-essential \


### PR DESCRIPTION
- eliminates usage of now deprecated `set-env`. Closes #99 
- migrates to using new official docker actions 
- now builds all image tags in a single build step instead of using a matrix.  This means image digests for each arch will match for the tags created.