### PR TITLE
Add consistent spacing for docker-compose devices.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - 80:80
     # devices:
     #  - /dev/ttyACM0:/dev/ttyACM0
-    # - /dev/video0:/dev/video0
+    #  - /dev/video0:/dev/video0
     volumes:
      - octoprint:/octoprint
     # uncomment the lines below to ensure camera streaming is enabled when


### PR DESCRIPTION
The video spacing is now consistent with ttyACM0 spacing.