### PR TITLE
update action dorny/paths-filter to 2.6.0

### DIFF
--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -120,7 +120,7 @@ jobs:
       - 
         uses: actions/checkout@v2
       - 
-        uses: dorny/paths-filter@v2.5.0
+        uses: dorny/paths-filter@v2.6.0
         id: filter
         with:
           filters: '.github/filters.yml'


### PR DESCRIPTION
This should resolve the warning about 'no `before` field in PUSH payload event that we're seeing in some runs of the release workflow.  ([example of warning](https://github.com/OctoPrint/octoprint-docker/actions/runs/403154220))

Per the release notes for 2.6.0 for paths-filter: https://github.com/dorny/paths-filter/releases/tag/v2.6.0