### PR TITLE
Enable backup restore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,12 +56,14 @@ RUN	curl -fsSLO --compressed --retry 3 --retry-delay 10 \
 
 WORKDIR /opt/octoprint
 RUN pip install .
+RUN mkdir -p /octoprint/octoprint /octoprint/plugins
 
 # Install mjpg-streamer
 RUN curl -fsSLO --compressed --retry 3 --retry-delay 10 \
   https://github.com/jacksonliam/mjpg-streamer/archive/master.tar.gz \
   && mkdir /mjpg \
   && tar xzf master.tar.gz -C /mjpg
+
 
 WORKDIR /mjpg/mjpg-streamer-master/mjpg-streamer-experimental
 RUN make

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ then run the following commands:
 docker-compose up -d config-editor
 ```
 
-Now go to `http://<octoprint_ip_or_url>:8443/?folder=/config` in your browser to edit your octoprint files!
+Now go to `http://<octoprint_ip_or_url>:8443/?folder=/octoprint` in your browser to edit your octoprint files!
 Use the 'explorer' (accessible by clicking the hamburger menu icon) to explore folder and files to load
 into the editor workspace. 
 
-All configuration files are in the `/config` folder, and the active configuration will be accessible at `/config/config.yaml`
+All configuration files are in the `octoprint` folder, and the active configuration will be accessible at `/octoprint/octoprint/config.yaml`
 
 When you're done, we recommend you stop and remove this service/container:
 

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -24,7 +24,7 @@ services:
       - GUID=0
       - TZ=America/Chicago
     volumes:
-      - octoprint:/config
+      - octoprint:/octoprint
 
 volumes:
   octoprint:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
   #    - GUID=0
   #    - TZ=America/Chicago
   #  volumes:
-  #    - octoprint:/config
+  #    - octoprint:/octoprint
 
 volumes:
   octoprint:

--- a/root/etc/services.d/octoprint/run
+++ b/root/etc/services.d/octoprint/run
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv sh
 
-exec octoprint serve --iknowwhatimdoing --host 0.0.0.0 --basedir /octoprint
+exec octoprint serve --iknowwhatimdoing --host 0.0.0.0 --basedir /octoprint/octoprint

--- a/root/octoprint/octoprint/config.yaml
+++ b/root/octoprint/octoprint/config.yaml
@@ -5,6 +5,3 @@ webcam:
   ffmpeg: /usr/bin/ffmpeg
   snapshot: http://localhost:8080/?action=snapshot
   stream: /webcam/?action=stream
-plugins:
-  _disabled:
-  - backup


### PR DESCRIPTION
- creates `/octoprint/octoprint` and `/octoprint/plugins` folders explicitly during docker build
- starts octoprint service using `--basedir /octoprint/octoprint` instead of just `/octoprint`
- changes the recommended mount path for the `config-editor` container to `octoprint:/octoprint`
  - updates the example and test compose files and README instructions to reflect this change


**BREAKING CHANGES** This may be a breaking change for existing users that are using a volume mounting strategy other than the recommended strategy, thus will constitue a new major release for the image. 

Where before the root context of the volume mount looked like this:

```
/octoprint
├── config.backup
├── config.yaml
├── data
│   ├── announcements
│   ├── appkeys
│   ├── backup
│   ├── pluginmanager
│   ├── preemptive_cache_config.yaml
│   └── softwareupdate
├── generated
│   └── webassets
├── logs
│   ├── octoprint.log
│   ├── plugin_bedlevelvisualizer_debug.log
│   ├── plugin_pluginmanager_console.log
│   └── plugin_softwareupdate_console.log
├── octoprint
│   ├── config.backup
│   ├── config.yaml
│   ├── data
│   ├── generated
│   ├── logs
│   ├── plugins
│   ├── printerProfiles
│   ├── scripts
│   ├── slicingProfiles
│   ├── timelapse
│   ├── translations
│   ├── uploads
│   ├── users.yaml
│   ├── virtualSd
│   └── watched
├── plugins
│   ├── bin
│   └── lib
├── printerProfiles
│   └── _default.profile
├── scripts
├── slicingProfiles
├── timelapse
│   └── tmp
├── translations
├── uploads
├── virtualSd
└── watched
```
It will now look like this:

```
/octoprint
├── octoprint
│   ├── config.backup
│   ├── config.yaml
│   ├── data
│   ├── generated
│   ├── logs
│   ├── plugins
│   ├── printerProfiles
│   ├── scripts
│   ├── slicingProfiles
│   ├── timelapse
│   ├── translations
│   ├── uploads
│   ├── virtualSd
│   └── watched
└── plugins
```

Note: the `/octoprint/plugins` directory is the python libraries path, and `/octoprint/octoprint/plugins` is the path for plugin data and configuration.  Prior to this change, both of these things existed in the `/octoprint/plugins` folder, polluting it's purpose.

This new method will allow savvy users to create distinct volumes for plugin binaries and octoprint configuration data, givinig them more ability to selectively control how state and memory consumption are utilized in their octoprint image usage/distribution strategies.