### PR TITLE
V3 image migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@
 
 ### Breaking changes
 
-PR #135 introduced a change that will not affect most users, but may be a breaking change for existing users that are using a volume mounting strategy other than the recommended strategy. Details follow: 
+PR #135 introduced a change that will not affect most users, but may be a breaking change for existing users that are using a volume mounting strategy other than the recommended strategy. 
 
--  `/octoprint/octoprint` and `/octoprint/plugins` folders are now explicitly created during docker build
+We have introduced an optional environment variable you can set to attempt to automigrate the file structures, but this feature was impossible to test for all condidtions, and as such is
+defaulted to `false`.  We highly recommend you use the OctoPrint backup feature, or use this [docker based method of backing up your container volume][container-backup] before attempting auto-migration. 
+To attempt auto-migration, set a container environment variable of `AUTOMIGRATE=true`.
+
+Details of breaking changes follow:
+
+- `/octoprint/octoprint` and `/octoprint/plugins` folders are now explicitly created during docker build
 - octoprint service basedir is now `/octoprint/octoprint` (was previously `/octoprint`)
 - the recommended mount path for the `config-editor` container to has been changed to `octoprint:/octoprint`. See updated examples and usage info in `docker-compose.yml` and `README`.
 
@@ -92,6 +98,8 @@ existed in the `/octoprint/plugins` folder, polluting it's purpose.
 This new method will allow savvy users to create distinct volumes for plugin binaries and
 octoprint configuration data, giving them more ability to selectively control how state and
 memory consumption are utilized in their octoprint image usage/distribution strategies.
+
+[container-backup]: https://docs.docker.com/storage/volumes/#backup-a-container
 
 ## 2.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ ENV CAMERA_DEV /dev/video0
 ENV MJPG_STREAMER_INPUT -y -n -r 640x480
 ENV PIP_USER true
 ENV PYTHONUSERBASE /octoprint/plugins
+ENV PATH "${PYTHONUSERBASE}/bin:${PATH}"
 # set WORKDIR 
 WORKDIR /octoprint
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,18 @@
 This is the primary image of `octoprint/octoprint`. It is designed to work similarly, and support the
 same out of the box features as the octopi raspberry-pi machine image, using docker.
 
+The `octoprint/octoprint` image uses semantic versioning, but the tags for `octoprint/octoprint` follow the
+version of octoprint contained in the image. As a result we recommend you always check the [CHANGELOG](CHANGELOG.md)
+or [Releases](https://github.com/OctoPrint/octoprint-docker/releases) before pulling an image, _even if you are pulling the same tag_.
+
+You can subscribe to be notified of releases as well, by selecting the Watch button in the upper right corner, 
+choosing "Custom", and checking "Releases".
+
+In addition, we know that OctoPrint is not the best suited type of application for containerization, but we're
+working hard to make it as compatible as possible. Please check out our [Roadmap](https://github.com/OctoPrint/octoprint-docker/projects/4),
+or join the discussion in the `#dev-docker` or `#support-docker` channels on the official OctoPrint Discord
+[discord.octoprint.org](https://discord.octoprint.org).
+
 **Tags**
 
 - `latest` - will always follow the latest _stable_ release 
@@ -57,11 +69,12 @@ There are configuration values that you pass using container `--environment` opt
 Listed below are the options and their defaults. These are implicit in example [docker-compose.yml](docker-compose.yml),
 and if you wish to change them, refer to the docker-compose docs on setting environment variables.
 
-| variable | default |
-| -------- | ------- |
-| `CAMERA_DEV` | `/dev/video0` (see [note](#devices_note)) |
-| `MJPG_STREAMER_INPUT` | `-y -n -r 640x480` |
-| `ENABLE_MJPG_STREAMER` | `false` |
+| variable | default | description |
+| -------- | ------- | ----------- |
+| `CAMERA_DEV` | `/dev/video0` | (see [note](#devices_note)) |
+| `MJPG_STREAMER_INPUT` | `-y -n -r 640x480` | params for mjpg-streamer |
+| `ENABLE_MJPG_STREAMER` | `false` | enable or disable mjpg-streamer
+| `AUTOMIGRATE` | `false` | Will attempt to detect and migrate filesystems structures from previous versions of this image to be compatible with the latest release version. recommend you backup before trying this as this is a new feature that has been difficult to test fully |
 
 **note:** You will still need to declare the `device` mapping in your docker-compose file or docker command,
 even if you explicitly declare the `CAMERA_DEV`.  The value of `CAMERA_DEV` is used in starting the mjpg-streamer

--- a/root/etc/cont-init.d/v3-dir-structure-check
+++ b/root/etc/cont-init.d/v3-dir-structure-check
@@ -6,6 +6,9 @@ if [[ -d "/octoprint/data" ]] || [[ -f "/octoprint/config.yaml" ]]; then
 
   [[ -d "/octoprint/octoprint/plugins/bin" ]] && mv /octoprint/octoprint/plugins/bin $PYTHONUSERBASE
   [[ -d "/octoprint/octoprint/plugins/lib" ]] && mv /octoprint/octoprint/plugins/lib $PYTHONUSERBASE
+  [[ -d "/octoprint/octoprint/plugins/include" ]] && mv /octoprint/octoprint/plugins/include $PYTHONUSERBASE
+  [[ -d "/octoprint/octoprint/plugins/local" ]] && mv /octoprint/octoprint/plugins/local $PYTHONUSERBASE
+  [[ -d "/octoprint/octoprint/plugins/share" ]] && mv /octoprint/octoprint/plugins/share $PYTHONUSERBASE
 
   echo "v3 octoprint-docker image migration complete!"
 fi

--- a/root/etc/cont-init.d/v3-dir-structure-check
+++ b/root/etc/cont-init.d/v3-dir-structure-check
@@ -3,8 +3,10 @@
 : "${AUTOMIGRATE:=false}"
 
 if $AUTOMIGRATE; then
+  echo "AUTOMIGATE enabled...."
   if [[ -d "/octoprint/data" ]] || [[ -f "/octoprint/config.yaml" ]]; then
-    echo "Migrating to octoprint-docker v3 directory structure..." && \
+    echo "octoprint-docker v2 directory structure detected...."
+    echo "migrating to octoprint-docker v3 directory structure..."
     mkdir -p /octoprint/octoprint /octoprint/plugins
     mv /octoprint/* /octoprint/octoprint
 
@@ -14,11 +16,12 @@ if $AUTOMIGRATE; then
     [[ -d "/octoprint/octoprint/plugins/local" ]] && mv /octoprint/octoprint/plugins/local $PYTHONUSERBASE
     [[ -d "/octoprint/octoprint/plugins/share" ]] && mv /octoprint/octoprint/plugins/share $PYTHONUSERBASE
 
-    echo "v2 -> v3 octoprint-docker image migration complete!"
+    echo "v2 -> v3 octoprint-docker auto-migration migration complete!"
   fi
 
   if [[ -d "/root/.octoprint" ]]; then
-    echo "octoprint-docker v1 directory structure detected, migrating to octoprint-docker v3 directory structure..."
+    echo "octoprint-docker v1 directory structure detected...."
+    echo "migrating to octoprint-docker v3 directory structure..."
 
     mkdir -p /octoprint/octoprint /octoprint/plugins
     mv /root/.octoprint/* /octoprint/octoprint
@@ -29,7 +32,7 @@ if $AUTOMIGRATE; then
     [[ -d "/octoprint/octoprint/plugins/local" ]] && mv /octoprint/octoprint/plugins/local $PYTHONUSERBASE
     [[ -d "/octoprint/octoprint/plugins/share" ]] && mv /octoprint/octoprint/plugins/share $PYTHONUSERBASE
 
-    echo "v1 -> v3 octoprint-docker image migration complete!"
+    echo "v1 -> v3 octoprint-docker auto-migration complete!"
   fi
 
 fi

--- a/root/etc/cont-init.d/v3-dir-structure-check
+++ b/root/etc/cont-init.d/v3-dir-structure-check
@@ -2,6 +2,7 @@
 
 if [[ -d "/octoprint/data" ]] || [[ -f "/octoprint/config.yaml" ]]; then
   echo "Migrating to octoprint-docker v3 directory structure..." && \
+  mkdir -p /octoprint/octoprint /octoprint/plugins
   mv /octoprint/* /octoprint/octoprint
 
   [[ -d "/octoprint/octoprint/plugins/bin" ]] && mv /octoprint/octoprint/plugins/bin $PYTHONUSERBASE
@@ -10,12 +11,13 @@ if [[ -d "/octoprint/data" ]] || [[ -f "/octoprint/config.yaml" ]]; then
   [[ -d "/octoprint/octoprint/plugins/local" ]] && mv /octoprint/octoprint/plugins/local $PYTHONUSERBASE
   [[ -d "/octoprint/octoprint/plugins/share" ]] && mv /octoprint/octoprint/plugins/share $PYTHONUSERBASE
 
-  echo "v3 octoprint-docker image migration complete!"
+  echo "v2 -> v3 octoprint-docker image migration complete!"
 fi
 
 if [[ -d "/root/.octoprint" ]]; then
   echo "octoprint-docker v1 directory structure detected, migrating to octoprint-docker v3 directory structure..."
 
+  mkdir -p /octoprint/octoprint /octoprint/plugins
   mv /root/.octoprint/* /octoprint/octoprint
 
   [[ -d "/octoprint/octoprint/plugins/bin" ]] && mv /octoprint/octoprint/plugins/bin $PYTHONUSERBASE
@@ -24,5 +26,5 @@ if [[ -d "/root/.octoprint" ]]; then
   [[ -d "/octoprint/octoprint/plugins/local" ]] && mv /octoprint/octoprint/plugins/local $PYTHONUSERBASE
   [[ -d "/octoprint/octoprint/plugins/share" ]] && mv /octoprint/octoprint/plugins/share $PYTHONUSERBASE
 
-  echo "v3 octoprint-docker image migration complete!"
+  echo "v1 -> v3 octoprint-docker image migration complete!"
 fi

--- a/root/etc/cont-init.d/v3-dir-structure-check
+++ b/root/etc/cont-init.d/v3-dir-structure-check
@@ -1,30 +1,35 @@
 #!/usr/bin/with-contenv bash
 
-if [[ -d "/octoprint/data" ]] || [[ -f "/octoprint/config.yaml" ]]; then
-  echo "Migrating to octoprint-docker v3 directory structure..." && \
-  mkdir -p /octoprint/octoprint /octoprint/plugins
-  mv /octoprint/* /octoprint/octoprint
+: "${AUTOMIGRATE:=false}"
 
-  [[ -d "/octoprint/octoprint/plugins/bin" ]] && mv /octoprint/octoprint/plugins/bin $PYTHONUSERBASE
-  [[ -d "/octoprint/octoprint/plugins/lib" ]] && mv /octoprint/octoprint/plugins/lib $PYTHONUSERBASE
-  [[ -d "/octoprint/octoprint/plugins/include" ]] && mv /octoprint/octoprint/plugins/include $PYTHONUSERBASE
-  [[ -d "/octoprint/octoprint/plugins/local" ]] && mv /octoprint/octoprint/plugins/local $PYTHONUSERBASE
-  [[ -d "/octoprint/octoprint/plugins/share" ]] && mv /octoprint/octoprint/plugins/share $PYTHONUSERBASE
+if $AUTOMIGRATE; then
+  if [[ -d "/octoprint/data" ]] || [[ -f "/octoprint/config.yaml" ]]; then
+    echo "Migrating to octoprint-docker v3 directory structure..." && \
+    mkdir -p /octoprint/octoprint /octoprint/plugins
+    mv /octoprint/* /octoprint/octoprint
 
-  echo "v2 -> v3 octoprint-docker image migration complete!"
-fi
+    [[ -d "/octoprint/octoprint/plugins/bin" ]] && mv /octoprint/octoprint/plugins/bin $PYTHONUSERBASE
+    [[ -d "/octoprint/octoprint/plugins/lib" ]] && mv /octoprint/octoprint/plugins/lib $PYTHONUSERBASE
+    [[ -d "/octoprint/octoprint/plugins/include" ]] && mv /octoprint/octoprint/plugins/include $PYTHONUSERBASE
+    [[ -d "/octoprint/octoprint/plugins/local" ]] && mv /octoprint/octoprint/plugins/local $PYTHONUSERBASE
+    [[ -d "/octoprint/octoprint/plugins/share" ]] && mv /octoprint/octoprint/plugins/share $PYTHONUSERBASE
 
-if [[ -d "/root/.octoprint" ]]; then
-  echo "octoprint-docker v1 directory structure detected, migrating to octoprint-docker v3 directory structure..."
+    echo "v2 -> v3 octoprint-docker image migration complete!"
+  fi
 
-  mkdir -p /octoprint/octoprint /octoprint/plugins
-  mv /root/.octoprint/* /octoprint/octoprint
+  if [[ -d "/root/.octoprint" ]]; then
+    echo "octoprint-docker v1 directory structure detected, migrating to octoprint-docker v3 directory structure..."
 
-  [[ -d "/octoprint/octoprint/plugins/bin" ]] && mv /octoprint/octoprint/plugins/bin $PYTHONUSERBASE
-  [[ -d "/octoprint/octoprint/plugins/lib" ]] && mv /octoprint/octoprint/plugins/lib $PYTHONUSERBASE
-  [[ -d "/octoprint/octoprint/plugins/include" ]] && mv /octoprint/octoprint/plugins/include $PYTHONUSERBASE
-  [[ -d "/octoprint/octoprint/plugins/local" ]] && mv /octoprint/octoprint/plugins/local $PYTHONUSERBASE
-  [[ -d "/octoprint/octoprint/plugins/share" ]] && mv /octoprint/octoprint/plugins/share $PYTHONUSERBASE
+    mkdir -p /octoprint/octoprint /octoprint/plugins
+    mv /root/.octoprint/* /octoprint/octoprint
 
-  echo "v1 -> v3 octoprint-docker image migration complete!"
+    [[ -d "/octoprint/octoprint/plugins/bin" ]] && mv /octoprint/octoprint/plugins/bin $PYTHONUSERBASE
+    [[ -d "/octoprint/octoprint/plugins/lib" ]] && mv /octoprint/octoprint/plugins/lib $PYTHONUSERBASE
+    [[ -d "/octoprint/octoprint/plugins/include" ]] && mv /octoprint/octoprint/plugins/include $PYTHONUSERBASE
+    [[ -d "/octoprint/octoprint/plugins/local" ]] && mv /octoprint/octoprint/plugins/local $PYTHONUSERBASE
+    [[ -d "/octoprint/octoprint/plugins/share" ]] && mv /octoprint/octoprint/plugins/share $PYTHONUSERBASE
+
+    echo "v1 -> v3 octoprint-docker image migration complete!"
+  fi
+
 fi

--- a/root/etc/cont-init.d/v3-dir-structure-check
+++ b/root/etc/cont-init.d/v3-dir-structure-check
@@ -12,3 +12,17 @@ if [[ -d "/octoprint/data" ]] || [[ -f "/octoprint/config.yaml" ]]; then
 
   echo "v3 octoprint-docker image migration complete!"
 fi
+
+if [[ -d "/root/.octoprint" ]]; then
+  echo "octoprint-docker v1 directory structure detected, migrating to octoprint-docker v3 directory structure..."
+
+  mv /root/.octoprint/* /octoprint/octoprint
+
+  [[ -d "/octoprint/octoprint/plugins/bin" ]] && mv /octoprint/octoprint/plugins/bin $PYTHONUSERBASE
+  [[ -d "/octoprint/octoprint/plugins/lib" ]] && mv /octoprint/octoprint/plugins/lib $PYTHONUSERBASE
+  [[ -d "/octoprint/octoprint/plugins/include" ]] && mv /octoprint/octoprint/plugins/include $PYTHONUSERBASE
+  [[ -d "/octoprint/octoprint/plugins/local" ]] && mv /octoprint/octoprint/plugins/local $PYTHONUSERBASE
+  [[ -d "/octoprint/octoprint/plugins/share" ]] && mv /octoprint/octoprint/plugins/share $PYTHONUSERBASE
+
+  echo "v3 octoprint-docker image migration complete!"
+fi

--- a/root/etc/cont-init.d/v3-dir-structure-check
+++ b/root/etc/cont-init.d/v3-dir-structure-check
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/usr/bin/with-contenv bash
 
-if [[ -d /octoprint/data ]]; then
+if [[ -d "/octoprint/data" ]] || [[ -f "/octoprint/config.yaml" ]]; then
   echo "Migrating to octoprint-docker v3 directory structure..." && \
   mv /octoprint/* /octoprint/octoprint
 
-  [[ -d /octoprint/octoprint/plugins/bin ]] && mv /octoprint/octoprint/plugins/bin /octoprint/plugins
-  [[ -d /octoprint/octoprint/plugins/lib ]] && mv /octoprint/octoprint/plugins/lib /octoprint/plugins
+  [[ -d "/octoprint/octoprint/plugins/bin" ]] && mv /octoprint/octoprint/plugins/bin $PYTHONUSERBASE
+  [[ -d "/octoprint/octoprint/plugins/lib" ]] && mv /octoprint/octoprint/plugins/lib $PYTHONUSERBASE
 
   echo "v3 octoprint-docker image migration complete!"
 fi

--- a/root/etc/cont-init.d/v3-dir-structure-check
+++ b/root/etc/cont-init.d/v3-dir-structure-check
@@ -1,8 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 
-[[ -d /octoprint/data ]] && \
+if [[ -d /octoprint/data ]]; then
   echo "Migrating to octoprint-docker v3 directory structure..." && \
-  mv /octoprint/* /octoprint/octoprint && \
-  mv /octoprint/octoprint/plugins/bin /octoprint/plugins && \
-  mv /octoprint/octoprint/plugins/lib /octoprint/plugins && \
+  mv /octoprint/* /octoprint/octoprint
+
+  [[ -d /octoprint/octoprint/plugins/bin ]] && mv /octoprint/octoprint/plugins/bin /octoprint/plugins
+  [[ -d /octoprint/octoprint/plugins/lib ]] && mv /octoprint/octoprint/plugins/lib /octoprint/plugins
+
   echo "v3 octoprint-docker image migration complete!"
+fi

--- a/root/etc/cont-init.d/v3-dir-structure-check
+++ b/root/etc/cont-init.d/v3-dir-structure-check
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+[[ -d /octoprint/data ]] && \
+  echo "Migrating to octoprint-docker v3 directory structure..." && \
+  mv /octoprint/* /octoprint/octoprint && \
+  mv /octoprint/octoprint/plugins/bin /octoprint/plugins && \
+  mv /octoprint/octoprint/plugins/lib /octoprint/plugins && \
+  echo "v3 octoprint-docker image migration complete!"

--- a/test/compose.test.yml
+++ b/test/compose.test.yml
@@ -11,6 +11,8 @@ services:
       - 53333:80
     volumes:
       - octoprint:/octoprint
+    environment:
+      - AUTOMIGRATE=true
 
   config-editor:
     image: linuxserver/code-server

--- a/test/compose.test.yml
+++ b/test/compose.test.yml
@@ -5,7 +5,7 @@ services:
     build: 
       context: ../
       args:
-        octoprint_ref: 1.5.1
+        octoprint_ref: 1.5.2
     image: octoprint/octoprint:test
     ports:
       - 53333:80


### PR DESCRIPTION
- closes #141 
- closes #138 

Instead of creating a migration strategy guide in the release docs, I went the route of detecting when a v3 container was being started with a v2 file structure, and then auto-migrate the file structures for them during container initialization.

This would potentially be a breaking release, in the event that two octoprint containers are using the same volume and the second container is added while the first (which is a v2 container) is running.

However, I've decided against classifying this as a breaking change (and thereby requiring a v4 release), because the current design of octoprint and octoprint in docker does not really support horizontal scaling due to the requirements to bind a host device.