### PR TITLE
add skeletons for CONTRIBUTING and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing to the official octoprint Docker image
+
+Call for maintainers! Are you experienced with Docker? Are you an OctoPrint enthusiast?
+Do you have a hour or more of time to spare each week answering questions about octoprint-docker
+and reviewing PR's? Let us know! 
+
+If this sounds like you, join the [OctoPrint Discord][] and message `@CHIEFdotJS` in the `#dev-docker` channel.
+
+## The remainder of this doc is a WIP
+
+see https://github.com/OctoPrint/octoprint-docker/issues/144#issuecomment-744482436
+
+[OctoPrint Discord]: https://discord.octoprint.org

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ or join the discussion in the `#dev-docker` or `#support-docker` channels on the
 - `X`,`X.Y`,`X.Y.Z`,`X.Y.Z-rc` - these tags will follow the latest build that matches the tag
 
 **Table of Contents**
-- [OctoPrint-docker](#octoprint-docker)
+- [OctoPrint-docker ![Chat](https://discord.octoprint.org)](#octoprint-docker-)
   - [Usage](#usage)
     - [Configuration](#configuration)
       - [Enabling Webcam Support with Docker](#enabling-webcam-support-with-docker)
@@ -32,6 +32,7 @@ or join the discussion in the `#dev-docker` or `#support-docker` channels on the
       - [Editing Config files manually](#editing-config-files-manually)
   - [Without docker-compose](#without-docker-compose)
   - [Building the image yourself](#building-the-image-yourself)
+  - [Contributions Welcome](#contributions-welcome)
 
 ## Usage
 
@@ -125,4 +126,8 @@ docker run -d -v octoprint:/octoprint --device /dev/ttyACM0:/dev/ttyACM0 --devic
 
 ## Building the image yourself
 
-If you would like to build the docker image yourself, please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to do so.
+If you would like to build the docker image yourself, please read [docs/building-an-octoprint-image](docs/building-an-octoprint-image.md)
+
+## Contributions Welcome
+
+We are welcoming contributions, and looking to add maintainers to the team. View [CONTRIBUTING.md](CONTRIBUTING.md) for more info!

--- a/docs/building-an-octoprint-image.md
+++ b/docs/building-an-octoprint-image.md
@@ -1,0 +1,14 @@
+# Building your own octoprint image
+
+In some circumstances, the best approach will be to build off of the base
+`octoprint/octoprint` image and add your own customizations and reproducible
+builds. Here are a few common scenarios you might find yourself wanting to do this:
+
+- you require additional OS packages for plugins
+- you want to distribute your own special version of OctoPrint 
+- you want a common set of plugins installed for a distributable image
+
+Docs coming soon, but this will follow common Docker usage, and here are a few good
+resources:
+
+- [Dockerfile Tutorial with Example | Creating your First Dockerfile | Docker Training | Edureka](https://https://www.youtube.com/watch?v=2lU9zdrs9bM)


### PR DESCRIPTION
creates skeleton for `CONTRIBUTING.md` and a `docs` folder for more expansive user instructions. 

related to #145 and #144 