### PR TITLE
Remove `-y` from default mjpg streamer params

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN make install
 # Copy services into s6 servicedir and set default ENV vars
 COPY root /
 ENV CAMERA_DEV /dev/video0
-ENV MJPG_STREAMER_INPUT -y -n -r 640x480
+ENV MJPG_STREAMER_INPUT -n -r 640x480
 ENV PIP_USER true
 ENV PYTHONUSERBASE /octoprint/plugins
 ENV PATH "${PYTHONUSERBASE}/bin:${PATH}"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ and if you wish to change them, refer to the docker-compose docs on setting envi
 | variable | default | description |
 | -------- | ------- | ----------- |
 | `CAMERA_DEV` | `/dev/video0` | (see [note](#devices_note)) |
-| `MJPG_STREAMER_INPUT` | `-y -n -r 640x480` | params for mjpg-streamer |
+| `MJPG_STREAMER_INPUT` | `-n -r 640x480` | params for mjpg-streamer |
 | `ENABLE_MJPG_STREAMER` | `false` | enable or disable mjpg-streamer
 | `AUTOMIGRATE` | `false` | Will attempt to detect and migrate filesystems structures from previous versions of this image to be compatible with the latest release version. recommend you backup before trying this as this is a new feature that has been difficult to test fully |
 


### PR DESCRIPTION
See #164 

**I haven't tested this**, just made the PR because I felt like being nice. If there are extra changes that need to happen, I'll happily leave and take my limited docker knowledge away, you won't miss much.