### PR TITLE
Docker composer tip

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     restart: unless-stopped
     ports:
       - 80:80
+    # if you are consider enabling the following lines
+    # take a look at docker composer version 3 and privileged flag
+    # otherwise your container is not going to run until you don't have the devices connected
     # devices:
     #  - /dev/ttyACM0:/dev/ttyACM0
     #  - /dev/video0:/dev/video0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     restart: unless-stopped
     ports:
       - 80:80
-    # if you are consider enabling the following lines
-    # take a look at docker composer version 3 and privileged flag
-    # otherwise your container is not going to run until you don't have the devices connected
+    # if you consider enabling the following lines
+    # take a look at docker composer version 3 and privileged option
+    # otherwise your container is not going to start until you have the devices connected
     # devices:
     #  - /dev/ttyACM0:/dev/ttyACM0
     #  - /dev/video0:/dev/video0


### PR DESCRIPTION
Little tip for people that is going to enable devices.

Priveleged helps you starting the container even if you don't have the devices connected, otherwise the container is not going to start.