### PR TITLE
adds command to discover usb device name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     ports:
       - 80:80
     # devices:
+    # use `python -m serial.tools.miniterm` to see what the name is of the printer
     #  - /dev/ttyACM0:/dev/ttyACM0
     #  - /dev/video0:/dev/video0
     volumes:


### PR DESCRIPTION
The device listed was not right for my printer. using the command allowed me to list them and then pug in my printer and rerun to find the correct name 