### PR TITLE
feat(config): pre-configure command for restarting OctoPrint service

### DIFF
--- a/minimal/config.yaml
+++ b/minimal/config.yaml
@@ -1,2 +1,5 @@
 accessControl:
     userfile: /octoprint/octoprint/users.yaml
+server:
+    commands:
+        serverRestartCommand: s6-svc -r /var/run/s6/services/octoprint


### PR DESCRIPTION
relates to #90

The command suggested in the issue as well as the README is working perfectly fine.

The README says

> Whilst the container should be pre-configured to allow for OctoPrint to be restarted within the container

-- I couldn't find such pre-configuration. Is there a reason to not include it in the default config?

