### PR TITLE
add a note that pyserial is needed for miniterm

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - 80:80
     # devices:
-    # use `python -m serial.tools.miniterm` to see what the name is of the printer
+    # use `python -m serial.tools.miniterm` to see what the name is of the printer, this requires pyserial
     #  - /dev/ttyACM0:/dev/ttyACM0
     #  - /dev/video0:/dev/video0
     volumes:


### PR DESCRIPTION
It took me a little bit to figure out how to run
```sh
python -m serial.tools.miniterm
```
and based on the question [here](https://github.com/OctoPrint/octoprint-docker/discussions/212), I wasn't the only one, so just a little hint on how to be able to run the command