### PR TITLE
Include libusb-dev and libudev-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN apt-get update && apt-get install -y \
   libjpeg-dev \
   libjpeg62-turbo \
   libprotobuf-dev \
+  libudev-dev \
+  libusb-1.0-0-dev \
   libv4l-dev \
   openssh-client \
   v4l-utils \


### PR DESCRIPTION
Facilitate plugin support of libusb, libudev and hid devices

Such as https://plugins.octoprint.org/plugins/usbrelaycontrol/ - it fails to install in Octoprint docker without the above packages

Related issue at https://github.com/abudden/OctoPrint-USBRelayControl/issues/1#issuecomment-1057791175