### PR TITLE
Add libffi-dev to dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get install -y \
   g++ \
   git \
   haproxy \
+  libffi-dev \
   libjpeg-dev \
   libjpeg62-turbo \
   libprotobuf-dev \


### PR DESCRIPTION
We need this to be able to successfully build `argon2-cffi` and its dependencies, which is now a dependency of OctoPrint 1.8.3+

Closes #234

PS: I have **not** been able to run the multi arch tests since I currently lack the time to do that. But I don't see why a standard package like `libffi-dev` should not be available on all target archs, and indeed [it is as far as I can see](https://packages.debian.org/buster/libffi-dev).