### PR TITLE
correct GUID typo on the code-server compose section

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
   #  restart: unless-stopped
   #  environment:
   #    - PUID=0
-  #    - GUID=0
+  #    - PGID=0
   #    - TZ=America/Chicago
   #  volumes:
   #    - octoprint:/octoprint


### PR DESCRIPTION
GUID is not a valid envvar in our (code-server) container, it should be PGID. As a side note, while this MAY work fine, we don't support a PUID/PGID of 0.
