### PR TITLE
:sparkles: Add support multiple cameras on same port

### DIFF
--- a/root/etc/services.d/mjpg-streamer/run
+++ b/root/etc/services.d/mjpg-streamer/run
@@ -1,15 +1,18 @@
-#!/usr/bin/with-contenv sh
+#!/usr/bin/with-contenv bash
 
 if [ -n "$MJPEG_STREAMER_INPUT" ]; then
-  echo "Deprecation warning: the environment variable '\$MJPEG_STREAMER_INPUT' was renamed to '\$MJPG_STREAMER_INPUT'"
-
+  echo "Deprecation warning: the environment variable '$MJPEG_STREAMER_INPUT' was renamed to '$MJPG_STREAMER_INPUT'"
   MJPG_STREAMER_INPUT=$MJPEG_STREAMER_INPUT
 fi
 
-if ! expr "$MJPG_STREAMER_INPUT" : ".*\.so.*" > /dev/null; then
+if ! echo "$MJPG_STREAMER_INPUT" | grep -q "..so."; then
   MJPG_STREAMER_INPUT="input_uvc.so $MJPG_STREAMER_INPUT"
 fi
 
-exec mjpg_streamer \
-  -i "/usr/local/lib/mjpg-streamer/$MJPG_STREAMER_INPUT -d $CAMERA_DEV" \
-  -o "/usr/local/lib/mjpg-streamer/output_http.so -w /usr/local/share/mjpg-streamer/www -p 8080"
+IFS=',' read -ra CAMERA_DEVS <<<"$CAMERA_DEV"
+CAMERA_ARGS=""
+for CAMERA in ${CAMERA_DEVS[*]}; do
+  CAMERA_ARGS="$CAMERA_ARGS -i \"/usr/local/lib/mjpg-streamer/${MJPG_STREAMER_INPUT} -d ${CAMERA}\""
+done
+
+eval "exec mjpg_streamer $CAMERA_ARGS -o '/usr/local/lib/mjpg-streamer/output_http.so -w /usr/local/share/mjpg-streamer/www -p 8080'"


### PR DESCRIPTION
Simple but working way to add support for multiple cameras; tested on a Raspberry Pi 3 with two different cameras.

You need to pass both cameras to the container via `--device` and use a comma separated list of devices on the environmental variable `CAMERA_DEV=/dev/video0,/dev/video2`

This should address the revert of #250 