### PR TITLE
Fixes for 1.9 - Babel app not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_BASE_IMAGE=3.8-slim-buster
+ARG PYTHON_BASE_IMAGE=3.10-slim-bullseye
 
 FROM ubuntu AS s6build
 ARG S6_RELEASE

--- a/root/etc/haproxy/haproxy.cfg
+++ b/root/etc/haproxy/haproxy.cfg
@@ -16,8 +16,8 @@ defaults
         option forwardfor
         maxconn 2000
         timeout connect 5s
-        timeout client  15min
-        timeout server  15min
+        timeout client  15m
+        timeout server  15m
 
 frontend public
         bind *:80
@@ -25,10 +25,10 @@ frontend public
         default_backend octoprint
 
 backend octoprint
-        reqrep ^([^\ :]*)\ /(.*)     \1\ /\2
+        http-request replace-path /(.*)     /\1
         option forwardfor
         server octoprint1 127.0.0.1:5000
 
 backend webcam
-        reqrep ^([^\ :]*)\ /webcam/(.*)     \1\ /\2
+        http-request replace-path /webcam/(.*)     /\1
         server webcam1  127.0.0.1:8080


### PR DESCRIPTION
By changing the docker version from 3.8 to 3.10-slim-bullseye, it seems to fix #259.

This also updates the haproxy.cfg to the latest version requirements as there have been some changes there as well for the config. 

In the docker logs there are still issues around webcam endpoints.

2023-06-01 00:10:48,907 - octoprint.settings - WARNING - DeprecationWarning: Detected access to deprecated settings path ['webcam', 'snapshot'], returned value is derived from compatibility overlay. Please use the webcam system introduced with 1.9.0, this compatibility layer will be removed in a future release.

