### PR TITLE
Enable HTTP/2 protocol by default in HaProxy

### DIFF
--- a/root/etc/haproxy/haproxy.cfg
+++ b/root/etc/haproxy/haproxy.cfg
@@ -20,7 +20,7 @@ defaults
         timeout server  15m
 
 frontend public
-        bind *:80
+        bind *:80 alpn h2,http/1.1
         use_backend webcam if { path_beg /webcam/ }
         default_backend octoprint
 


### PR DESCRIPTION
HTTP2 nowadays is a must have feature to improve the speed of the webservices.