### PR TITLE
Allow the `apt-get` steps to be cached when rebuilding with different `octoprint_ref` build argument.

### DIFF
--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -2,9 +2,6 @@ ARG PYTHON_BASE_IMAGE=3-slim-buster
 
 FROM python:${PYTHON_BASE_IMAGE} AS build
 
-ARG octoprint_ref 
-ENV octoprint_ref ${octoprint_ref:-master}
-
 RUN apt-get update && apt-get install -y \
   build-essential \
   curl \
@@ -25,6 +22,9 @@ WORKDIR /home/octoprint
 ENV PYTHONUSERBASE /octoprint/plugins
 ENV PIP_USER true
 ENV PATH "${PYTHONUSERBASE}/bin:${PATH}"
+
+ARG octoprint_ref 
+ENV octoprint_ref ${octoprint_ref:-master}
 
 RUN	mkdir tmp && curl -fsSLO --compressed --retry 3 --retry-delay 10 \
   https://github.com/OctoPrint/OctoPrint/archive/${octoprint_ref}.tar.gz \


### PR DESCRIPTION
My Raspberry Pi 1 is slow and with different `octoprint_ref` value, it takes an hour to redo the `apt-get` step. Moving the `ARG` further down, right before where it is used, makes caching more effective.