### PR TITLE
Update v3-dir-structure-check (fixed spelling error)

### DIFF
--- a/root/etc/cont-init.d/v3-dir-structure-check
+++ b/root/etc/cont-init.d/v3-dir-structure-check
@@ -3,7 +3,7 @@
 : "${AUTOMIGRATE:=false}"
 
 if $AUTOMIGRATE; then
-  echo "AUTOMIGATE enabled...."
+  echo "AUTOMIGRATE enabled...."
   if [[ -d "/octoprint/data" ]] || [[ -f "/octoprint/config.yaml" ]]; then
     echo "octoprint-docker v2 directory structure detected...."
     echo "migrating to octoprint-docker v3 directory structure..."


### PR DESCRIPTION
Fixed spelling on line 6:
was:
echo "AUTOMIGATE enabled...."
now:
echo "AUTOMIGRATE enabled...."