### PR TITLE
chore: update deprecated github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashfiles('**/Dockerfile') }}
@@ -98,7 +98,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashfiles('**/Dockerfile') }}

--- a/.github/workflows/octoprint-release.yml
+++ b/.github/workflows/octoprint-release.yml
@@ -60,7 +60,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Cache Docker Layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashfiles('**/Dockerfile') }}
@@ -147,7 +147,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Cache Docker Layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashfiles('**/Dockerfile') }}
@@ -255,7 +255,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Cache Docker Layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashfiles('**/Dockerfile') }}
@@ -337,7 +337,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Cache Docker Layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashfiles('**/Dockerfile') }}


### PR DESCRIPTION
actions/cache{v1|v2} will cease functioning on Feb 1st, see https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/